### PR TITLE
overload toJSON to support toJSON(file);

### DIFF
--- a/index.js
+++ b/index.js
@@ -178,18 +178,22 @@ module.exports = {};`
   }
 
   toJSON() {
-    return {
-      [this.name]: Object.assign({
-        'node_modules': depsAsObject([
-          ...this.devDependencies(),
-          ...this.dependencies()
-        ]),
-        'package.json': JSON.stringify(Object.assign(this.pkg, {
-          dependencies: depsToObject(this.dependencies()),
-          devDependencies: depsToObject(this.devDependencies()),
-        }), null, 2),
-      }, this.files),
-    };
+    if (arguments.length > 0) {
+      return this.toJSON()[this.name][arguments[0]];
+    } else {
+      return {
+        [this.name]: Object.assign({
+          'node_modules': depsAsObject([
+            ...this.devDependencies(),
+            ...this.dependencies()
+          ]),
+          'package.json': JSON.stringify(Object.assign(this.pkg, {
+            dependencies: depsToObject(this.dependencies()),
+            devDependencies: depsToObject(this.devDependencies()),
+          }), null, 2),
+        }, this.files),
+      };
+    }
   }
 
   clone() {

--- a/test.js
+++ b/test.js
@@ -236,5 +236,23 @@ describe('Project', function() {
 
     expect(project.pkg.name, 'pink');
     expect(project.pkg.version, '1');
-  })
+  });
+
+  it('to JSON with 1 arg, is an alias for toJSON()[project.name][arg]', function() {
+    let project = new Project('foo', '123');
+    project.addDependency('rsvp', '1.2.3');
+    project.addDevDependency('q', '1.2.4');
+
+    expect(JSON.parse(project.toJSON('package.json'))).to.deep.eql({
+      name: 'foo',
+      version: '123',
+      keywords: [],
+      dependencies: {
+        rsvp: '1.2.3'
+      },
+      devDependencies: {
+        q: '1.2.4'
+      },
+    });
+  });
 });


### PR DESCRIPTION
Which is a short-hand for:

```js
toJSON()[project.name][file]
```

Open questions:

- [x] should it suports paths?
- [x] should it's property access start at the name of the project or the root of the json
- [x] should it be a new method