### PR TITLE
support scoped packages

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -323,4 +323,12 @@ describe('Project', function() {
     project.dispose();
     expect(fs.existsSync(project.root)).to.eql(false);
   });
+
+  it('supports namespaced packages', function() {
+    let project = new Project('@ember/foo');
+    expect(project.name, '@ember/foo');
+    project.writeSync();
+    expect(fs.readdirSync(project.root)).to.eql(["@ember"]);
+    expect(fs.readdirSync(path.join(project.root, '@ember'))).to.eql(["foo"]);
+  });
 });


### PR DESCRIPTION
Prior to this change, you can't make the top level Project have a scoped name. Scoped names were supported inside dependencies only. Now the top-level and the dependencies are handled consistently and both correctly represent their scoped names in their toJSON output.