### PR TITLE
bugfix: Handle Scoped Packages

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -328,7 +328,19 @@ function parseScoped(name: string) {
 function depsAsObject(modules: Project[]) {
   let obj: { [name: string]: string | fixturify.DirJSON } = {};
   modules.forEach(dep => {
-    Object.assign(obj, dep.toJSON());
+    let depJSON =  dep.toJSON();
+    if (dep.name.charAt(0) === '@') {
+      let [scope] = dep.name.split('/');
+      if (obj[scope] === undefined) {
+        Object.assign(obj, depJSON);
+      } else {
+        Object.assign(obj[scope], depJSON[scope]);
+      }
+
+    } else {
+      Object.assign(obj, depJSON);
+    }
+
   });
   return obj;
 }

--- a/test.ts
+++ b/test.ts
@@ -2,6 +2,7 @@ import chai = require('chai');
 import Project = require('./index');
 import fs = require('fs-extra');
 import path = require('path');
+import { DirJSON } from 'fixturify';
 
 const expect = chai.expect;
 
@@ -311,6 +312,28 @@ describe('Project', function() {
         q: '1.2.4'
       },
     });
+  });
+
+  it('handles scoped deps', function() {
+    let project = new Project('foo', '123');
+    project.addDependency('@test/foo', '1.0.0');
+    project.addDependency('@test/bar', '1.0.0');
+    project.writeSync();
+    let foo = project.toJSON().foo as DirJSON;
+    let node_modules = foo && foo.node_modules as DirJSON;
+    let scope = node_modules && node_modules['@test'] as DirJSON;
+    expect(Object.keys(scope)).to.deep.equal(['foo', 'bar'])
+  });
+
+  it('handles scoped devDeps', function() {
+    let project = new Project('foo', '123');
+    project.addDevDependency('@test/foo', '1.0.0');
+    project.addDevDependency('@test/bar', '1.0.0');
+    project.writeSync();
+    let foo = project.toJSON().foo as DirJSON;
+    let node_modules = foo && foo.node_modules as DirJSON;
+    let scope = node_modules && node_modules['@test'] as DirJSON;
+    expect(Object.keys(scope)).to.deep.equal(['foo', 'bar'])
   });
 
   it('has a working dispose to allow early cleanup', function() {


### PR DESCRIPTION
Prior to this PR the scopes would get overwritten instead of merged
leaving you with a last merge win scenario. This PR checks to see if the
package is scoped prior to merging and merges one layer down if it is.