### PR TITLE
Don't publish sourcemap

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
   },
   "files": [
     "index.js",
-    "index.d.ts",
-    "index.js.map"
+    "index.d.ts"
   ],
   "scripts": {
     "test": "mocha test -r source-map-support/register",


### PR DESCRIPTION
We should either publish the sourcemap *and* index.ts or neither.  Publishing the map (which refers to index.ts) without index.ts is a worse debugging experience than no map at all.

Both files remain available when linking locally.
