### PR TITLE
Drop erroneous recursion

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -301,9 +301,10 @@ export class Project {
   }
 
   private hardLinkContents(target: string, destination: string) {
+    fs.ensureDirSync(destination);
     for (let entry of entries(target, { ignore: ['node_modules'] })) {
       if (entry.isDirectory()) {
-        this.hardLinkContents(entry.fullPath, path.join(destination, entry.relativePath));
+        fs.ensureDirSync(path.join(destination, entry.relativePath));
       } else {
         this.hardLinkFile(entry.fullPath, path.join(destination, entry.relativePath));
       }
@@ -313,7 +314,7 @@ export class Project {
   private hardLinkFile(source: string, destination: string) {
     if (this.usingHardLinks) {
       try {
-        fs.ensureLinkSync(source, destination);
+        fs.linkSync(source, destination);
         return;
       } catch (err: any) {
         if (err.code !== 'EXDEV') {


### PR DESCRIPTION
This was left behind after we switch from readdirSync to walkSync.entries.