### PR TITLE
Fix odd double project directory structure when resolving linked deps

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -348,12 +348,12 @@ export class Project {
     if (opts?.linkDeps || opts?.linkDevDeps) {
       if (this.pkg.dependencies) {
         for (let dep of Object.keys(this.pkg.dependencies)) {
-          this.linkDependency(dep, { baseDir: path.join(root, this.name) });
+          this.linkDependency(dep, { baseDir: root });
         }
       }
       if (this.pkg.devDependencies && opts.linkDevDeps) {
         for (let dep of Object.keys(this.pkg.devDependencies)) {
-          this.linkDevDependency(dep, { baseDir: path.join(root, this.name) });
+          this.linkDevDependency(dep, { baseDir: root });
         }
       }
     } else {


### PR DESCRIPTION
this `${root}/${this.name}` is a remnant of a previous world, where `root` did not include the project name. It does now

I don’t believe this causes a serious problem, as I think the node resolution algorithm still falls back from `project-path/project-name/project-name` to `project-path/project-name`. That being said, it is surprising, and may lead to other unexpected issues