### PR TITLE
Fixes typeguard to correctly evaluate Error type when globals don't match

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -613,8 +613,12 @@ function unwrapPackageName(obj: any, packageName: string): fixturify.DirJSON {
   return getFolder(obj, packageName);
 }
 
+function isError(e: unknown): e is Error {
+  return !!e && typeof e === 'object' && Object.prototype.toString.call(e) === '[object Error]' && 'message' in e;
+}
+
 function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
-  return e instanceof Error && 'code' in e;
+  return isError(e) && 'code' in e;
 }
 
 function readString(name: string): string | undefined {

--- a/index.ts
+++ b/index.ts
@@ -614,7 +614,7 @@ function unwrapPackageName(obj: any, packageName: string): fixturify.DirJSON {
 }
 
 function isObject(e: unknown): e is Object {
-  return e !== null && typeof e === 'object';
+  return e !== null && typeof e === 'object' && !Array.isArray(e);
 }
 
 function isErrnoException(e: unknown): e is NodeJS.ErrnoException {

--- a/index.ts
+++ b/index.ts
@@ -613,12 +613,12 @@ function unwrapPackageName(obj: any, packageName: string): fixturify.DirJSON {
   return getFolder(obj, packageName);
 }
 
-function isError(e: unknown): e is Error {
-  return !!e && typeof e === 'object' && Object.prototype.toString.call(e) === '[object Error]' && 'message' in e;
+function isObject(e: unknown): e is Object {
+  return e !== null && typeof e === 'object';
 }
 
 function isErrnoException(e: unknown): e is NodeJS.ErrnoException {
-  return isError(e) && 'code' in e;
+  return isObject(e) && 'code' in e;
 }
 
 function readString(name: string): string | undefined {


### PR DESCRIPTION
The typeguard [added here](https://github.com/stefanpenner/node-fixturify-project/commit/a9ab547e246f57aed6a1a35748650f0b595dc742#diff-dcdc3e0b3362edb8fec2a51d3fa51f8fb8af8f70247e06d9887fa934834c9122R616-R618) seems completely reasonable, but fails in `jest` environments due to https://github.com/facebook/jest/issues/11808. 

I've attempted to reasonable duck type the Error check, but am open to adjustments. Additionally, I'm unsure how to provide a reasonable test for this short of adding a separate test using jest, which would manifest this problem.