### PR TITLE
Adding write(dirJSON), mergeFiles APIs

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "bin-links": "^3.0.0",
+    "deepmerge": "^4.2.2",
     "fixturify": "^2.1.1",
     "resolve-package-path": "^4.0.3",
     "tmp": "^0.0.33",

--- a/src/index.ts
+++ b/src/index.ts
@@ -257,15 +257,18 @@ export class Project {
     this.pkg.version = value;
   }
 
-  async write() {
-    this.writeProject();
-    await this.binLinks();
+  mergeFiles(dirJSON: fixturify.DirJSON) {
+    this.files = deepmerge(this.files, dirJSON);
   }
 
-  writeDirJSON(dirJSON: fixturify.DirJSON) {
-    this.files = deepmerge(this.files, dirJSON);
+  async write(dirJSON?: fixturify.DirJSON): Promise<void> {
+    if (dirJSON) {
+      this.mergeFiles(dirJSON);
+    }
 
-    return this.write();
+    this.writeProject();
+
+    await this.binLinks();
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import binLinks from 'bin-links';
 import { PackageJson as BasePackageJson } from 'type-fest';
 import walkSync from 'walk-sync';
 import { deprecate } from 'util';
+import deepmerge from 'deepmerge';
 const { entries } = walkSync;
 
 type PackageJson = BasePackageJson & Record<string, any>; // we also allow adding arbitrary key/value pairs to a PackageJson
@@ -259,6 +260,12 @@ export class Project {
   async write() {
     this.writeProject();
     await this.binLinks();
+  }
+
+  writeDirJSON(dirJSON: fixturify.DirJSON) {
+    this.files = deepmerge(this.files, dirJSON);
+
+    return this.write();
   }
 
   /**

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -3,6 +3,7 @@ import path from 'path';
 import { readSync } from 'fixturify';
 import { describe, it, expect } from 'vitest';
 import { Project } from '../src/index';
+import walkSync from 'walk-sync';
 
 describe('Project', async () => {
   function readJSON(file: string) {
@@ -96,6 +97,34 @@ describe('Project', async () => {
     expect(nodeModules.sort()).to.eql(['@ember', 'ember-cli', 'ember-source']);
 
     expect(index).to.eql('module.exports = "Hello, World!";');
+  });
+
+  it('can write a DirJSON', async function () {
+    let project = new Project({
+      name: 'rsvp',
+      version: '3.1.4',
+    });
+
+    await project.write();
+
+    await project.writeDirJSON({
+      top: {
+        middle: {
+          bottom: {
+            'foo.js': 'console.log("bar");',
+          },
+        },
+      },
+    });
+
+    expect(walkSync(project.baseDir)).to.eql([
+      'index.js',
+      'package.json',
+      'top/',
+      'top/middle/',
+      'top/middle/bottom/',
+      'top/middle/bottom/foo.js',
+    ]);
   });
 
   describe('project constructor with callback DSL', function () {

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -105,9 +105,7 @@ describe('Project', async () => {
       version: '3.1.4',
     });
 
-    await project.write();
-
-    await project.writeDirJSON({
+    await project.write({
       top: {
         middle: {
           bottom: {

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -125,6 +125,35 @@ describe('Project', async () => {
     ]);
   });
 
+  it('can merge files in the correct order', async function () {
+    let project = new Project({
+      name: 'rsvp',
+      version: '3.1.4',
+      files: {
+        'foo.js': 'console.log("bar");',
+      },
+    });
+
+    expect(project.files).to.eql({
+      'foo.js': 'console.log("bar");',
+      'index.js': `
+    'use strict';
+     module.exports = {};`,
+    });
+
+    project.mergeFiles({
+      'bar.js': 'console.log("baz");',
+    });
+
+    expect(project.files).to.eql({
+      'foo.js': 'console.log("bar");',
+      'bar.js': 'console.log("baz");',
+      'index.js': `
+    'use strict';
+     module.exports = {};`,
+    });
+  });
+
   describe('project constructor with callback DSL', function () {
     it('name, version, cb', async () => {
       const projects: { [key: string]: Project } = {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -802,6 +802,11 @@ deep-extend@^0.6.0:
   resolved "https://registry.yarnpkg.com/deep-extend/-/deep-extend-0.6.0.tgz#c4fa7c95404a17a9c3e8ca7e1537312b736330ac"
   integrity sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 defaults@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/defaults/-/defaults-1.0.3.tgz#c656051e9817d9ff08ed881477f3fe4019f3ef7d"


### PR DESCRIPTION
The `write` API requires you to first mutate the `files` property, and subsequently call `write` to apply the changes. This PR adds a new method that allows a single call that encapsulates both. It allows you to pass a `DirJSON` to the method, which will deeply merge with the `files` property, and subsequently call `write`.

There's a number of examples of packages adding this functionality themselves, so pulling that into the core package seems to make sense here. Happy to discuss further.