### PR TITLE
Fixes ESM output

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dist"
   ],
   "scripts": {
-    "build": "tsup src/index.ts --format cjs,esm --dts --clean",
+    "build": "tsup-node src/index.ts --format cjs,esm --external 'fs-extra' --dts --clean",
     "docs:generate": "readme-api-generator src/index.ts --ts",
     "lint": "yarn prettier --check *.ts",
     "prepare": "yarn build",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import tmp from 'tmp';
 import fs from 'fs-extra';
 import path from 'path';
 import resolvePackagePath from 'resolve-package-path';
-import CacheGroup from 'resolve-package-path/lib/cache-group';
+import CacheGroup from 'resolve-package-path/lib/cache-group.js';
 import binLinks from 'bin-links';
 import { PackageJson as BasePackageJson } from 'type-fest';
 import walkSync from 'walk-sync';


### PR DESCRIPTION
After the 5.x release, I noticed two issues when integrating with other projects (both cjs and esm).

1. When using with pure ESM projects, an error occurs with the subdir import [here](https://github.com/stefanpenner/node-fixturify-project/blob/master/src/index.ts#L6). The fix was specifying the `.js` extension explicitly, which works in both cjs and esm.
2. The transpiled output was incorrectly inlining some dependencies, which is not desirable, particularly in a Node environment, and very particularly in an ESM one. Specifying the library to be considered external was required to resolve this.

Fixes #68 