### PR TITLE
provide access to baseDir before write

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -165,15 +165,6 @@ export class Project {
    */
   get baseDir() {
     if (!this._baseDir) {
-      throw new Error(
-        `this project has no baseDir yet. Either set one manually or call write to have one chosen for you`
-      );
-    }
-    return this._baseDir;
-  }
-
-  private autoBaseDir(): string {
-    if (!this._baseDir) {
       this._tmp = tmp.dirSync({ unsafeCleanup: true });
       this._baseDir = fs.realpathSync(this._tmp.name);
     }
@@ -454,7 +445,7 @@ export class Project {
   }
 
   private assignBaseDirs() {
-    this.autoBaseDir();
+    this.baseDir;
     for (let depList of [this.dependencyProjects(), this.devDependencyProjects()]) {
       for (let dep of depList) {
         dep.baseDir = path.join(this.baseDir, 'node_modules', dep.name);


### PR DESCRIPTION
I ran into a use case wahere I want to know project.basDir before writing out the files, but I don't really want to be responsible for creating my own tmpdir. This change makes it legal to access `project.baseDir`, creating it automatically as usual when you first ask for it.

Since that was an exception before, this is backward compatible.