### PR TITLE
Bump Node to 16, drop deprecated methods

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['14', '16', '18']
+        node: ['16', '18']
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ project.addDependency('chai', '5.2.0');
 project.pkg; // => the contents of package.json for the given project
 project.files; // => read or write the set of files further
 
-// if you don't set this, a new temp dir will be made for you when you writeSync()
+// if you don't set this, a new temp dir will be made for you when you write()
 project.baseDir = 'some/base/dir/';
 
 await project.write();
 
-// after writeSync(), you can read project.baseDir even if you didn't set it
+// after write(), you can read project.baseDir even if you didn't set it
 expect(fs.existsSync(join(project.baseDir, 'index.js'))).to.eql(true);
 ```
 
@@ -144,7 +144,6 @@ appropriate for apps) you can use `linkDevDeps` instead.
     - [project.version](#projectversion)
     - [project.mergeFiles(dirJSON)](#projectmergefilesdirjson)
     - [project.write(dirJSON?)](#projectwritedirjson)
-    - [~~project.writeSync()~~](#projectwritesync)
     - [project.addDependency() ⇒](#projectadddependency-)
     - [project.addDevDependency() ⇒](#projectadddevdependency-)
     - [project.removeDependency(name)](#projectremovedependencyname)
@@ -218,14 +217,6 @@ appropriate for apps) you can use `linkDevDeps` instead.
 | Param | Description |
 | --- | --- |
 | dirJSON? | <p>An optional object containing a directory representation to write.</p> |
-
-<a name="Project+writeSync"></a>
-
-### ~~project.writeSync()~~
-***Deprecated***
-
-**Kind**: instance method of [<code>Project</code>](#Project)
-<a name="Project+addDependency"></a>
 
 ### project.addDependency() ⇒
 <p>Adds a dependency to the Project's package.json.</p>

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ project.pkg; // => the contents of package.json for the given project
 project.files; // => read or write the set of files further
 
 // if you don't set this, a new temp dir will be made for you when you writeSync()
-project.baseDir = 'some/root/';
+project.baseDir = 'some/base/dir/';
 
 await project.write();
 
@@ -40,10 +40,10 @@ The above example produces the following files (and most importantly the
 appropriate file contents:
 
 ```sh
-some/root/package.json
-some/root/index.js
-some/root/node_modules/mocha/package.json
-some/root/node_modules/chai/package.json
+some/base/dir/package.json
+some/base/dir/index.js
+some/base/dir/node_modules/mocha/package.json
+some/base/dir/node_modules/chai/package.json
 ```
 
 ### Nesting Dependencies
@@ -136,12 +136,11 @@ appropriate for apps) you can use `linkDevDeps` instead.
     - [Linking to real dependencies](#linking-to-real-dependencies)
   - [API](#api)
   - [Project](#project)
-    - [~~project.root~~](#projectroot)
     - [project.baseDir](#projectbasedir)
     - [project.baseDir](#projectbasedir-1)
-    - [project.name : <code>string</code>](#projectname--string)
+    - [project.name : string](#projectname--string)
     - [project.name](#projectname)
-    - [project.version : <code>string</code>](#projectversion--string)
+    - [project.version : string](#projectversion--string)
     - [project.version](#projectversion)
     - [project.mergeFiles(dirJSON)](#projectmergefilesdirjson)
     - [project.write(dirJSON?)](#projectwritedirjson)
@@ -156,16 +155,7 @@ appropriate for apps) you can use `linkDevDeps` instead.
     - [project.devDependencyProjects() ⇒](#projectdevdependencyprojects-)
     - [project.clone() ⇒](#projectclone-)
     - [project.dispose()](#projectdispose)
-    - [Project.fromDir(root, opts) ⇒](#projectfromdirroot-opts-)
-
-<a name="Project+root"></a>
-
-### ~~project.root~~
-***Deprecated***
-
-**Kind**: instance property of [<code>Project</code>](#Project)
-**Read only**: true
-<a name="Project+baseDir"></a>
+    - [Project.fromDir(baseDir, opts) ⇒](#projectfromdirbasedir-opts-)
 
 ### project.baseDir
 <p>Sets the base directory of the project.</p>
@@ -326,8 +316,8 @@ appropriate for apps) you can use `linkDevDeps` instead.
 **Kind**: instance method of [<code>Project</code>](#Project)
 <a name="Project.fromDir"></a>
 
-### Project.fromDir(root, opts) ⇒
-<p>Reads an existing project from the specified root.</p>
+### Project.fromDir(baseDir, opts) ⇒
+<p>Reads an existing project from the specified base dir.</p>
 
 **Kind**: static method of [<code>Project</code>](#Project)
 **Returns**: <ul>
@@ -336,7 +326,7 @@ appropriate for apps) you can use `linkDevDeps` instead.
 
 | Param | Description |
 | --- | --- |
-| root | <p>The base directory to read the project from.</p> |
+| baseDir | <p>The base directory to read the project from.</p> |
 | opts | <p>An options object.</p> |
 | opts.linkDeps | <p>Include linking dependencies from the Project's node_modules.</p> |
 | opts.linkDevDeps | <p>Include linking devDependencies from the Project's node_modules.</p> |

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import CacheGroup from 'resolve-package-path/lib/cache-group.js';
 import binLinks from 'bin-links';
 import { PackageJson as BasePackageJson } from 'type-fest';
 import walkSync from 'walk-sync';
-import { deprecate } from 'util';
 import deepmerge from 'deepmerge';
 const { entries } = walkSync;
 
@@ -236,13 +235,6 @@ export class Project {
     this.writeProject();
 
     await this.binLinks();
-  }
-
-  /**
-   * @deprecated Please use `await project.write()` instead.
-   */
-  writeSync() {
-    this.writeProject();
   }
 
   addDependency(
@@ -803,11 +795,6 @@ function readPackages(modulesPath: string): { pkg: PackageJson; path: string }[]
   }
   return pkgs;
 }
-
-Project.prototype.writeSync = deprecate(
-  Project.prototype.writeSync,
-  'project.writeSync() is deprecated. Use await project.write() instead'
-);
 
 export type LinkParams =
   | { baseDir: string; resolveName?: string; requestedRange?: string }

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,16 +135,6 @@ export class Project {
   }
 
   /**
-   * @deprecated Please use baseDir instead.
-   *
-   * @readonly
-   * @memberof Project
-   */
-  get root() {
-    throw new Error('.root has been removed, please review the readme but you likely actually want .baseDir now');
-  }
-
-  /**
    * Sets the base directory of the project.
    *
    * @memberof Project
@@ -210,17 +200,17 @@ export class Project {
   }
 
   /**
-   * Reads an existing project from the specified root.
+   * Reads an existing project from the specified base dir.
    *
-   * @param root - The base directory to read the project from.
+   * @param baseDir - The base directory to read the project from.
    * @param opts - An options object.
    * @param opts.linkDeps - Include linking dependencies from the Project's node_modules.
    * @param opts.linkDevDeps - Include linking devDependencies from the Project's node_modules.
    * @returns - The deserialized Project.
    */
-  static fromDir(root: string, opts?: ReadDirOpts): Project {
+  static fromDir(baseDir: string, opts?: ReadDirOpts): Project {
     let project = new Project();
-    project.readSync(root, opts);
+    project.readSync(baseDir, opts);
     return project;
   }
 
@@ -571,8 +561,8 @@ export class Project {
     fs.copyFileSync(source, destination, fs.constants.COPYFILE_FICLONE | fs.constants.COPYFILE_EXCL);
   }
 
-  private readSync(root: string, opts?: ReadDirOpts): void {
-    const files = fixturify.readSync(root, {
+  private readSync(baseDir: string, opts?: ReadDirOpts): void {
+    const files = fixturify.readSync(baseDir, {
       // when linking deps, we don't need to crawl all of node_modules
       ignore: opts?.linkDeps || opts?.linkDevDeps ? ['node_modules'] : [],
     });
@@ -585,12 +575,12 @@ export class Project {
     if (opts?.linkDeps || opts?.linkDevDeps) {
       if (this.pkg.dependencies) {
         for (let dep of Object.keys(this.pkg.dependencies)) {
-          this.linkDependency(dep, { baseDir: root });
+          this.linkDependency(dep, { baseDir });
         }
       }
       if (this.pkg.devDependencies && opts.linkDevDeps) {
         for (let dep of Object.keys(this.pkg.devDependencies)) {
-          this.linkDevDependency(dep, { baseDir: root });
+          this.linkDevDependency(dep, { baseDir });
         }
       }
     } else {


### PR DESCRIPTION
This is a follow-up to https://github.com/stefanpenner/node-fixturify-project/pull/83 .

As part of removing `project.root`, I also renamed a few instances of the `root` argument: it's more consistent and `{ baseDir }` looks nicer than `{ baseDir: root }`.