### PR TITLE
Fix #86 Files leak across instances of Project

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,6 @@ export interface ProjectArgs {
 
 tmp.setGracefulCleanup();
 
-// This only shallow-merges with any user-provided files, which is OK right now
-// because this is only one level deep. If we ever make it deeper, we'll need to
-// switch to a proper deep merge.
 const defaultFiles = {
   'index.js': `
     'use strict';
@@ -107,7 +104,7 @@ export class Project {
 
     if (files && typeof files?.['package.json'] === 'string') {
       pkg = JSON.parse(files['package.json']);
-      files = Object.assign({}, files);
+      files = deepmerge({}, files);
       delete files['package.json'];
     }
 
@@ -117,9 +114,9 @@ export class Project {
       keywords: pkg.keywords || [],
     });
     if (files) {
-      this.files = { ...defaultFiles, ...files };
+      this.files = deepmerge({}, { ...defaultFiles, ...files });
     } else {
-      this.files = defaultFiles;
+      this.files = deepmerge({}, defaultFiles);
     }
     this.requestedRange = requestedRange || this.pkg.version!;
 

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -896,4 +896,13 @@ describe('Project', async () => {
 
     expect(execFileSync(path.join(binPath, 'goodbye'), { encoding: 'utf8' })).to.eql('goodbye\n');
   });
+
+  it('should not share files', function () {
+    let project1 = new Project('my-app', '1.0.0');
+    project1.files['foo.js'] = 'foo';
+
+    let project2 = new Project('my-app', '1.0.0');
+
+    expect(project2.files['foo.js']).to.be.undefined;
+  })
 });


### PR DESCRIPTION
See #86.

We already depend on `deepmerge`, it's a shame not to use it. 😬 