### PR TITLE
fix incorrect usage of named import

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,9 @@ import deepmerge from 'deepmerge';
 import { findWorkspaceDir } from '@pnpm/find-workspace-dir';
 import { findWorkspacePackages } from '@pnpm/workspace.find-packages';
 import { packlist } from '@pnpm/fs.packlist';
-import { PackageCache } from '@embroider/shared-internals';
+import embroiderSharedInternals from '@embroider/shared-internals';
+
+const { PackageCache } = embroiderSharedInternals;
 
 // we also allow adding arbitrary key/value pairs to a PackageJson
 type PackageJson = BasePackageJson & Record<string, any>;


### PR DESCRIPTION
I recently tried to update to the latest fixturify-project version and there seems to be an issue with the import of `@embroider/shared-internals` when consumed from ESM: https://github.com/embroider-build/create-release-plan-setup/actions/runs/8949736763/job/24584372856#step:6:21

This PR fixes it 👍 