### PR TITLE
don't error about missing optional peer deps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -567,8 +567,22 @@ export class Project {
       }
     }
 
+    // collect a list of optional peers
+    let optionalPeers = [];
+    for (let depName of Object.keys(targetPkg['peerDependenciesMeta'] ?? {})) {
+      if (targetPkg['peerDependenciesMeta'][depName]?.optional === true) {
+        optionalPeers.push(depName);
+      }
+    }
+
     for (let depName of depsToLink) {
       let depTarget = resolvePackagePath(depName, target, this.resolutionCache);
+
+      if (!depTarget && optionalPeers.includes(depName)) {
+        // don't link or error about missing optional peer deps
+        continue;
+      }
+
       if (!depTarget) {
         throw new Error(
           `[FixturifyProject] package ${name} in ${target} depends on ${depName} but we could not resolve it`


### PR DESCRIPTION
I noticed in https://github.com/embroider-build/embroider/pull/1897 we had an error: 

```vite depends on less but we could not resolve it```

but less is an **optional** peer dep of vite. I'm assuming this is a subtlety that crept in with the changes in https://github.com/stefanpenner/node-fixturify-project/pull/95