### PR TITLE
fix windows hard links

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -652,10 +652,9 @@ export class Project {
         if (err.code === 'EEXIST') {
           debugger;
         }
-        if (err.code !== 'EXDEV') {
-          throw err;
+        if (err.code === 'EXDEV') {
+          this.usingHardLinks = false;
         }
-        this.usingHardLinks = false;
       }
     }
     fs.copyFileSync(source, destination, fs.constants.COPYFILE_FICLONE | fs.constants.COPYFILE_EXCL);


### PR DESCRIPTION
Windows has a limit of 1024 hard links per file . So this can fail quickly. Considering that pnpm also uses hard links. Apparently it can also fail for unknown reasons 🤷‍♂️.
We never encountered it before, because on windows in github actions tmp is always on C drive, while the CWD is on D drive...
and hard links are not permitted cross device.

this changes it to the same behaviour pnpm has https://github.com/pnpm/pnpm/blob/6e031e7428b3e46fc093f47a5702ac8510703a91/fs/indexed-pkg-importer/src/index.ts#L190