### PR TITLE
fix CI by turning off cron

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,13 +3,16 @@ name: CI
 on:
   push:
     branches:
+      - main
       - master
       - 'v*' # older version branches
     tags:
       - '*'
   pull_request: {}
-  schedule:
-    - cron: '0 6 * * 0' # weekly, on sundays
+
+concurrency:
+  group: ci-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -23,10 +26,8 @@ jobs:
         os: [ubuntu-latest, macOS-latest, windows-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v3
+      - uses: pnpm/action-setup@v4
         name: Install pnpm
-        with:
-          version: 7
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}

--- a/package.json
+++ b/package.json
@@ -76,5 +76,6 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
-  }
+  },
+  "packageManager": "pnpm@8.15.9+sha512.499434c9d8fdd1a2794ebf4552b3b25c0a633abcee5bb15e7b5de90f32f47b513aca98cd5cfd001c31f0db454bc3804edccd578501e4ca293a6816166bbd9f81"
 }


### PR DESCRIPTION
CI has been turned off automatically because we have a cron setup in our action file and not many merges to master in the last while 😞 (thanks crypto bros) 

This turns off that cron so that will not happen again, but I think someone might need to either turn on CI again manually or merge a PR to get it going again 🤔 