### PR TITLE
only publish esm verison

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,19 +7,15 @@
   "type": "module",
   "exports": {
     ".": {
-      "require": "./dist/index.cjs",
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     }
   },
-  "main": "./dist/index.cjs",
-  "module": "./dist/index.js",
-  "types": "./dist/index.d.ts",
   "files": [
     "dist"
   ],
   "scripts": {
-    "build": "tsup-node src/index.ts --sourcemap --format cjs,esm --dts --clean",
+    "build": "tsc",
     "docs:generate": "readme-api-generator src/index.ts --ts",
     "lint": "pnpm prettier --check **/*.ts",
     "prepare": "pnpm build",
@@ -50,8 +46,7 @@
     "chai": "^4.3.4",
     "prettier": "^2.3.0",
     "release-plan": "^0.18.0",
-    "tsup": "^8.5.1",
-    "typescript": "^5.1.6",
+    "typescript": "^7.0.2",
     "vite": "^7.3.5",
     "vitest": "^4.1.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,12 +72,9 @@ importers:
       release-plan:
         specifier: ^0.18.0
         version: 0.18.0
-      tsup:
-        specifier: ^8.5.1
-        version: 8.5.1(postcss@8.5.15)(typescript@5.9.3)
       typescript:
-        specifier: ^5.1.6
-        version: 5.9.3
+        specifier: ^7.0.2
+        version: 7.0.2
       vite:
         specifier: ^7.3.5
         version: 7.3.5(@types/node@22.19.20)
@@ -1326,6 +1323,126 @@ packages:
   '@types/tmp@0.2.6':
     resolution: {integrity: sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA==}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    resolution: {integrity: sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    resolution: {integrity: sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    resolution: {integrity: sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    resolution: {integrity: sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    resolution: {integrity: sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    resolution: {integrity: sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    resolution: {integrity: sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    resolution: {integrity: sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    resolution: {integrity: sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    resolution: {integrity: sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    resolution: {integrity: sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    resolution: {integrity: sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    resolution: {integrity: sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    resolution: {integrity: sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    resolution: {integrity: sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    resolution: {integrity: sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    resolution: {integrity: sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    resolution: {integrity: sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    resolution: {integrity: sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
   '@vitest/expect@4.1.8':
     resolution: {integrity: sha512-h3nDO677RDLEGlBxyQ5CW8RlMThSKSRLUePLOx09gNIWRL40edgA1GCZSZgf1W55MFAG6/Sw14KeaAnqv0NKdQ==}
 
@@ -1358,11 +1475,6 @@ packages:
   '@zkochan/which@2.0.3':
     resolution: {integrity: sha512-C1ReN7vt2/2O0fyTsx5xnbQuxBrmG5NMSbcIkPKCCfCTJgpZBsuRYzFXHj3nVq8vTfK7vxHUmzfCpSHgO7j4rg==}
     engines: {node: '>= 8'}
-    hasBin: true
-
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
-    engines: {node: '>=0.4.0'}
     hasBin: true
 
   agent-base@6.0.2:
@@ -1526,16 +1638,6 @@ packages:
   builtins@5.1.0:
     resolution: {integrity: sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==}
 
-  bundle-require@5.1.0:
-    resolution: {integrity: sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-    peerDependencies:
-      esbuild: '>=0.18'
-
-  cac@6.7.14:
-    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
-    engines: {node: '>=8'}
-
   cacache@15.3.0:
     resolution: {integrity: sha512-VVdYzXEn+cnbXpFgWs5hTT7OScegHVmLhJIR8Ufqk3iFD6A6j5iSX1KuBTfNEv4tdJWE2PzA6IVFtcLC7fN9wQ==}
     engines: {node: '>= 10'}
@@ -1607,10 +1709,6 @@ packages:
     resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
     engines: {node: '>= 8.10.0'}
 
-  chokidar@4.0.3:
-    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
-    engines: {node: '>= 14.16.0'}
-
   chownr@2.0.0:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
@@ -1671,10 +1769,6 @@ packages:
     resolution: {integrity: sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==}
     engines: {node: '>=12.20.0'}
 
-  commander@4.1.1:
-    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
-    engines: {node: '>= 6'}
-
   commander@6.2.1:
     resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
     engines: {node: '>= 6'}
@@ -1686,18 +1780,11 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
-  confbox@0.1.8:
-    resolution: {integrity: sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==}
-
   config-chain@1.1.13:
     resolution: {integrity: sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==}
 
   config-master@3.1.0:
     resolution: {integrity: sha512-n7LBL1zBzYdTpF1mx5DNcZnZn05CWIdsdvtPL4MosvqbBUK3Rq6VWEtGUuF3Y0s9/CIhMejezqlSkP6TnCJ/9g==}
-
-  consola@3.4.2:
-    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
-    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1897,9 +1984,6 @@ packages:
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
-
-  fix-dts-default-cjs-exports@1.0.1:
-    resolution: {integrity: sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg==}
 
   fixturify@3.0.0:
     resolution: {integrity: sha512-PFOf/DT9/t2NCiVyiQ5cBMJtGZfWh3aeOV8XVqQQOPBlTv8r6l0k75/hm36JOaiJlrWFk/8aYFyOKAvOkrkjrw==}
@@ -2167,10 +2251,6 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
-  joycon@3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
-
   js-string-escape@1.0.1:
     resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
     engines: {node: '>= 0.8'}
@@ -2260,10 +2340,6 @@ packages:
     resolution: {integrity: sha512-7W0vV3rqv5tokqkBAFV1LbR7HPOWzXQDpDgEuib/aJ1jsZZx6x3c2mBI+TJhJzOhkGeaLbCKEHXEXLfirtG2JA==}
     engines: {node: '>=18'}
 
-  lilconfig@3.1.3:
-    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
-    engines: {node: '>=14'}
-
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
@@ -2273,10 +2349,6 @@ packages:
   load-json-file@6.2.0:
     resolution: {integrity: sha512-gUD/epcRms75Cw8RT1pUdHugZYM5ce64ucs2GEISABwkRsOQr0q2wm/MV2TKThycIe5e0ytRweW2RZxclogCdQ==}
     engines: {node: '>=8'}
-
-  load-tsconfig@0.2.5:
-    resolution: {integrity: sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
@@ -2449,9 +2521,6 @@ packages:
     resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
     engines: {node: '>=10'}
     hasBin: true
-
-  mlly@1.8.2:
-    resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -2673,33 +2742,8 @@ packages:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
 
-  pirates@4.0.7:
-    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
-    engines: {node: '>= 6'}
-
   pkg-entry-points@1.1.1:
     resolution: {integrity: sha512-BhZa7iaPmB4b3vKIACoppyUoYn8/sFs17VJJtzrzPZvEnN2nqrgg911tdL65lA2m1ml6UI3iPeYbZQ4VXpn1mA==}
-
-  pkg-types@1.3.1:
-    resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
-
-  postcss-load-config@6.0.1:
-    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
-    engines: {node: '>= 18'}
-    peerDependencies:
-      jiti: '>=1.21.0'
-      postcss: '>=8.0.9'
-      tsx: ^4.8.1
-      yaml: ^2.4.2
-    peerDependenciesMeta:
-      jiti:
-        optional: true
-      postcss:
-        optional: true
-      tsx:
-        optional: true
-      yaml:
-        optional: true
 
   postcss@8.5.15:
     resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
@@ -2795,10 +2839,6 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
-  readdirp@4.1.2:
-    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
-    engines: {node: '>= 14.18.0'}
-
   realpath-missing@1.1.0:
     resolution: {integrity: sha512-wnWtnywepjg/eHIgWR97R7UuM5i+qHLA195qdN9UPKvcMqfn60+67S8sPPW3vDlSEfYHoFkKU8IvpCNty3zQvQ==}
     engines: {node: '>=10'}
@@ -2843,10 +2883,6 @@ packages:
 
   requizzle@0.2.4:
     resolution: {integrity: sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==}
-
-  resolve-from@5.0.0:
-    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
-    engines: {node: '>=8'}
 
   resolve-package-path@4.0.3:
     resolution: {integrity: sha512-SRpNAPW4kewOaNUt8VPqhJ0UMxawMwzJD8V7m1cJfdSTK9ieZwS6K7Dabsm4bmLFM96Z5Y/UznrpG5kt1im8yA==}
@@ -2966,10 +3002,6 @@ packages:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
-  source-map@0.7.6:
-    resolution: {integrity: sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==}
-    engines: {node: '>= 12'}
-
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
 
@@ -3048,11 +3080,6 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
-  sucrase@3.35.1:
-    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
-    engines: {node: '>=16 || 14 >=14.17'}
-    hasBin: true
-
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3083,9 +3110,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@0.3.2:
-    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -3106,38 +3130,12 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
-  tree-kill@1.2.2:
-    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
-    hasBin: true
-
   trim-newlines@4.1.1:
     resolution: {integrity: sha512-jRKj0n0jXWo6kh62nA5TEh3+4igKDXLvzBJcPpiizP7oOolUrYIxmVBG9TOtHYFHoddUk6YvAkGeGoSVTXfQXQ==}
     engines: {node: '>=12'}
 
-  ts-interface-checker@0.1.13:
-    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
-
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
-
-  tsup@8.5.1:
-    resolution: {integrity: sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing==}
-    engines: {node: '>=18'}
-    hasBin: true
-    peerDependencies:
-      '@microsoft/api-extractor': ^7.36.0
-      '@swc/core': ^1
-      postcss: ^8.4.12
-      typescript: '>=4.5.0'
-    peerDependenciesMeta:
-      '@microsoft/api-extractor':
-        optional: true
-      '@swc/core':
-        optional: true
-      postcss:
-        optional: true
-      typescript:
-        optional: true
 
   type-detect@4.1.0:
     resolution: {integrity: sha512-Acylog8/luQ8L7il+geoSxhEkazvkslg7PSNKOX59mbB9cOveP5aq9h74Y7YU8yDpJwetzQQrfIwtf4Wp4LKcw==}
@@ -3167,9 +3165,9 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  typescript@5.9.3:
-    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
-    engines: {node: '>=14.17'}
+  typescript@7.0.2:
+    resolution: {integrity: sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==}
+    engines: {node: '>=16.20.0'}
     hasBin: true
 
   typical@7.3.0:
@@ -3178,9 +3176,6 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
-
-  ufo@1.6.4:
-    resolution: {integrity: sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==}
 
   uglify-js@3.19.3:
     resolution: {integrity: sha512-v3Xu+yuwBXisp6QYTcH4UbH+xYJXqnq2m/LtQVWKWzYc1iehYnLixoQDN9FH6/j9/oybfd6W9Ghwkl8+UMKTKQ==}
@@ -4869,6 +4864,66 @@ snapshots:
 
   '@types/tmp@0.2.6': {}
 
+  '@typescript/typescript-aix-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-darwin-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-freebsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-arm@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-loong64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-mips64el@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-ppc64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-riscv64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-s390x@7.0.2':
+    optional: true
+
+  '@typescript/typescript-linux-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-netbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-openbsd-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-sunos-x64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-arm64@7.0.2':
+    optional: true
+
+  '@typescript/typescript-win32-x64@7.0.2':
+    optional: true
+
   '@vitest/expect@4.1.8':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -4913,8 +4968,6 @@ snapshots:
   '@zkochan/which@2.0.3':
     dependencies:
       isexe: 2.0.0
-
-  acorn@8.16.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -5083,13 +5136,6 @@ snapshots:
     dependencies:
       semver: 7.8.2
 
-  bundle-require@5.1.0(esbuild@0.27.7):
-    dependencies:
-      esbuild: 0.27.7
-      load-tsconfig: 0.2.5
-
-  cac@6.7.14: {}
-
   cacache@15.3.0:
     dependencies:
       '@npmcli/fs': 1.1.1
@@ -5186,10 +5232,6 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
-  chokidar@4.0.3:
-    dependencies:
-      readdirp: 4.1.2
-
   chownr@2.0.0: {}
 
   clean-stack@2.2.0: {}
@@ -5253,15 +5295,11 @@ snapshots:
       table-layout: 4.1.1
       typical: 7.3.0
 
-  commander@4.1.1: {}
-
   commander@6.2.1: {}
 
   common-sequence@3.0.0: {}
 
   concat-map@0.0.1: {}
-
-  confbox@0.1.8: {}
 
   config-chain@1.1.13:
     dependencies:
@@ -5271,8 +5309,6 @@ snapshots:
   config-master@3.1.0:
     dependencies:
       walk-back: 2.0.1
-
-  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -5469,12 +5505,6 @@ snapshots:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-
-  fix-dts-default-cjs-exports@1.0.1:
-    dependencies:
-      magic-string: 0.30.21
-      mlly: 1.8.2
-      rollup: 4.61.1
 
   fixturify@3.0.0:
     dependencies:
@@ -5734,8 +5764,6 @@ snapshots:
 
   jju@1.4.0: {}
 
-  joycon@3.1.1: {}
-
   js-string-escape@1.0.1: {}
 
   js-tokens@4.0.0: {}
@@ -5831,8 +5859,6 @@ snapshots:
     dependencies:
       package-json: 10.0.1
 
-  lilconfig@3.1.3: {}
-
   lines-and-columns@1.2.4: {}
 
   linkify-it@5.0.1:
@@ -5845,8 +5871,6 @@ snapshots:
       parse-json: 5.2.0
       strip-bom: 4.0.0
       type-fest: 0.6.0
-
-  load-tsconfig@0.2.5: {}
 
   locate-path@6.0.0:
     dependencies:
@@ -6040,13 +6064,6 @@ snapshots:
 
   mkdirp@1.0.4: {}
 
-  mlly@1.8.2:
-    dependencies:
-      acorn: 8.16.0
-      pathe: 2.0.3
-      pkg-types: 1.3.1
-      ufo: 1.6.4
-
   ms@2.1.3: {}
 
   mz@2.7.0:
@@ -6238,21 +6255,7 @@ snapshots:
 
   pify@4.0.1: {}
 
-  pirates@4.0.7: {}
-
   pkg-entry-points@1.1.1: {}
-
-  pkg-types@1.3.1:
-    dependencies:
-      confbox: 0.1.8
-      mlly: 1.8.2
-      pathe: 2.0.3
-
-  postcss-load-config@6.0.1(postcss@8.5.15):
-    dependencies:
-      lilconfig: 3.1.3
-    optionalDependencies:
-      postcss: 8.5.15
 
   postcss@8.5.15:
     dependencies:
@@ -6338,8 +6341,6 @@ snapshots:
       picomatch: 2.3.2
     optional: true
 
-  readdirp@4.1.2: {}
-
   realpath-missing@1.1.0: {}
 
   redent@4.0.0:
@@ -6401,8 +6402,6 @@ snapshots:
   requizzle@0.2.4:
     dependencies:
       lodash: 4.18.1
-
-  resolve-from@5.0.0: {}
 
   resolve-package-path@4.0.3:
     dependencies:
@@ -6529,8 +6528,6 @@ snapshots:
 
   source-map@0.6.1: {}
 
-  source-map@0.7.6: {}
-
   spdx-correct@3.2.0:
     dependencies:
       spdx-expression-parse: 3.0.1
@@ -6605,16 +6602,6 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  sucrase@3.35.1:
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      commander: 4.1.1
-      lines-and-columns: 1.2.4
-      mz: 2.7.0
-      pirates: 4.0.7
-      tinyglobby: 0.2.17
-      ts-interface-checker: 0.1.13
-
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
@@ -6649,8 +6636,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@0.3.2: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.17:
@@ -6666,41 +6651,9 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
-  tree-kill@1.2.2: {}
-
   trim-newlines@4.1.1: {}
 
-  ts-interface-checker@0.1.13: {}
-
   tslib@2.8.1: {}
-
-  tsup@8.5.1(postcss@8.5.15)(typescript@5.9.3):
-    dependencies:
-      bundle-require: 5.1.0(esbuild@0.27.7)
-      cac: 6.7.14
-      chokidar: 4.0.3
-      consola: 3.4.2
-      debug: 4.4.3
-      esbuild: 0.27.7
-      fix-dts-default-cjs-exports: 1.0.1
-      joycon: 3.1.1
-      picocolors: 1.1.1
-      postcss-load-config: 6.0.1(postcss@8.5.15)
-      resolve-from: 5.0.0
-      rollup: 4.61.1
-      source-map: 0.7.6
-      sucrase: 3.35.1
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.17
-      tree-kill: 1.2.2
-    optionalDependencies:
-      postcss: 8.5.15
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - jiti
-      - supports-color
-      - tsx
-      - yaml
 
   type-detect@4.1.0: {}
 
@@ -6716,13 +6669,32 @@ snapshots:
 
   typescript@4.9.5: {}
 
-  typescript@5.9.3: {}
+  typescript@7.0.2:
+    optionalDependencies:
+      '@typescript/typescript-aix-ppc64': 7.0.2
+      '@typescript/typescript-darwin-arm64': 7.0.2
+      '@typescript/typescript-darwin-x64': 7.0.2
+      '@typescript/typescript-freebsd-arm64': 7.0.2
+      '@typescript/typescript-freebsd-x64': 7.0.2
+      '@typescript/typescript-linux-arm': 7.0.2
+      '@typescript/typescript-linux-arm64': 7.0.2
+      '@typescript/typescript-linux-loong64': 7.0.2
+      '@typescript/typescript-linux-mips64el': 7.0.2
+      '@typescript/typescript-linux-ppc64': 7.0.2
+      '@typescript/typescript-linux-riscv64': 7.0.2
+      '@typescript/typescript-linux-s390x': 7.0.2
+      '@typescript/typescript-linux-x64': 7.0.2
+      '@typescript/typescript-netbsd-arm64': 7.0.2
+      '@typescript/typescript-netbsd-x64': 7.0.2
+      '@typescript/typescript-openbsd-arm64': 7.0.2
+      '@typescript/typescript-openbsd-x64': 7.0.2
+      '@typescript/typescript-sunos-x64': 7.0.2
+      '@typescript/typescript-win32-arm64': 7.0.2
+      '@typescript/typescript-win32-x64': 7.0.2
 
   typical@7.3.0: {}
 
   uc.micro@2.1.0: {}
-
-  ufo@1.6.4: {}
 
   uglify-js@3.19.3:
     optional: true

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -4,907 +4,906 @@ import { readSync } from 'fixturify';
 import { describe, it, expect } from 'vitest';
 import walkSync from 'walk-sync';
 
-for (let version of ['cjs', 'js']) {
-  const { Project } = await import(`../dist/index.${version}`);
-  describe(`Project ${version}`, async () => {
-    function readJSON(file: string) {
-      return JSON.parse(fs.readFileSync(file, 'utf-8'));
-    }
+import { Project } from 'fixturify-project';
 
-    function read(file: string) {
-      return fs.readFileSync(file, 'utf-8');
-    }
+describe(`Project`, async () => {
+  function readJSON(file: string) {
+    return JSON.parse(fs.readFileSync(file, 'utf-8'));
+  }
 
-    function readDir(path: string) {
-      return fs.readdirSync(path);
-    }
+  function read(file: string) {
+    return fs.readFileSync(file, 'utf-8');
+  }
 
-    it('has the basic', async () => {
-      let project = new Project({
-        name: 'rsvp',
-        version: '3.1.4',
-        files: {
-          'index.js': `module.exports = "Hello, World!";`,
-        },
-      });
+  function readDir(path: string) {
+    return fs.readdirSync(path);
+  }
 
-      let emberCLI = project.addDependency('ember-cli', '3.1.1');
-      emberCLI.addDependency('console-ui', '3.3.3');
-      let rsvp = emberCLI.addDependency('rsvp', '3.1.4');
-
-      let source = project.addDevDependency('ember-source', '3.1.1');
-      project.addDevDependency('@ember/ordered-set', '3.1.1');
-      await project.write();
-
-      let index = read(`${project.baseDir}/index.js`);
-      let nodeModules = readDir(`${project.baseDir}/node_modules`);
-
-      expect(rsvp.baseDir).to.eql(path.normalize(`${project.baseDir}/node_modules/ember-cli/node_modules/rsvp`));
-      expect(source.baseDir).to.eql(path.normalize(`${project.baseDir}/node_modules/ember-source`));
-
-      expect(read(`${project.baseDir}/index.js`)).to.eql(`module.exports = "Hello, World!";`);
-
-      expect(readJSON(`${project.baseDir}/package.json`)).to.eql({
-        name: 'rsvp',
-        version: '3.1.4',
-        keywords: [],
-        dependencies: {
-          'ember-cli': '3.1.1',
-        },
-        devDependencies: {
-          '@ember/ordered-set': '3.1.1',
-          'ember-source': '3.1.1',
-        },
-      });
-
-      expect(read(`${project.baseDir}/node_modules/ember-source/index.js`)).to.contain(`module.exports`);
-      expect(require(`${project.baseDir}/node_modules/ember-source/index.js`)).to.eql({});
-
-      expect(readJSON(`${project.baseDir}/node_modules/ember-source/package.json`)).to.eql({
-        name: 'ember-source',
-        version: '3.1.1',
-        keywords: [],
-        dependencies: {},
-        devDependencies: {},
-      });
-
-      expect(readJSON(`${project.baseDir}/node_modules/ember-cli/package.json`)).to.eql({
-        name: 'ember-cli',
-        version: '3.1.1',
-        keywords: [],
-        dependencies: {
-          'console-ui': '3.3.3',
-          rsvp: '3.1.4',
-        },
-        devDependencies: {},
-      });
-
-      expect(read(`${project.baseDir}/node_modules/ember-cli/node_modules/console-ui/index.js`)).to.contain(
-        `module.exports`
-      );
-      expect(require(`${project.baseDir}/node_modules/ember-cli/node_modules/console-ui/index.js`)).to.eql({});
-
-      expect(read(`${project.baseDir}/node_modules/@ember/ordered-set/index.js`)).to.contain(`module.exports`);
-      expect(require(`${project.baseDir}/node_modules/@ember/ordered-set/index.js`)).to.eql({});
-
-      expect(readJSON(`${project.baseDir}/node_modules/ember-cli/node_modules/console-ui/package.json`)).to.eql({
-        name: 'console-ui',
-        version: '3.3.3',
-        keywords: [],
-        dependencies: {},
-        devDependencies: {},
-      });
-
-      expect(nodeModules.sort()).to.eql(['@ember', 'ember-cli', 'ember-source']);
-
-      expect(index).to.eql('module.exports = "Hello, World!";');
+  it('has the basic', async () => {
+    let project = new Project({
+      name: 'rsvp',
+      version: '3.1.4',
+      files: {
+        'index.js': `module.exports = "Hello, World!";`,
+      },
     });
 
-    it('can write a DirJSON', async function () {
-      let project = new Project({
-        name: 'rsvp',
-        version: '3.1.4',
-      });
+    let emberCLI = project.addDependency('ember-cli', '3.1.1');
+    emberCLI.addDependency('console-ui', '3.3.3');
+    let rsvp = emberCLI.addDependency('rsvp', '3.1.4');
 
-      await project.write({
-        top: {
-          middle: {
-            bottom: {
-              'foo.js': 'console.log("bar");',
-            },
+    let source = project.addDevDependency('ember-source', '3.1.1');
+    project.addDevDependency('@ember/ordered-set', '3.1.1');
+    await project.write();
+
+    let index = read(`${project.baseDir}/index.js`);
+    let nodeModules = readDir(`${project.baseDir}/node_modules`);
+
+    expect(rsvp.baseDir).to.eql(path.normalize(`${project.baseDir}/node_modules/ember-cli/node_modules/rsvp`));
+    expect(source.baseDir).to.eql(path.normalize(`${project.baseDir}/node_modules/ember-source`));
+
+    expect(read(`${project.baseDir}/index.js`)).to.eql(`module.exports = "Hello, World!";`);
+
+    expect(readJSON(`${project.baseDir}/package.json`)).to.eql({
+      name: 'rsvp',
+      version: '3.1.4',
+      keywords: [],
+      dependencies: {
+        'ember-cli': '3.1.1',
+      },
+      devDependencies: {
+        '@ember/ordered-set': '3.1.1',
+        'ember-source': '3.1.1',
+      },
+    });
+
+    expect(read(`${project.baseDir}/node_modules/ember-source/index.js`)).to.contain(`module.exports`);
+    expect(require(`${project.baseDir}/node_modules/ember-source/index.js`)).to.eql({});
+
+    expect(readJSON(`${project.baseDir}/node_modules/ember-source/package.json`)).to.eql({
+      name: 'ember-source',
+      version: '3.1.1',
+      keywords: [],
+      dependencies: {},
+      devDependencies: {},
+    });
+
+    expect(readJSON(`${project.baseDir}/node_modules/ember-cli/package.json`)).to.eql({
+      name: 'ember-cli',
+      version: '3.1.1',
+      keywords: [],
+      dependencies: {
+        'console-ui': '3.3.3',
+        rsvp: '3.1.4',
+      },
+      devDependencies: {},
+    });
+
+    expect(read(`${project.baseDir}/node_modules/ember-cli/node_modules/console-ui/index.js`)).to.contain(
+      `module.exports`
+    );
+    expect(require(`${project.baseDir}/node_modules/ember-cli/node_modules/console-ui/index.js`)).to.eql({});
+
+    expect(read(`${project.baseDir}/node_modules/@ember/ordered-set/index.js`)).to.contain(`module.exports`);
+    expect(require(`${project.baseDir}/node_modules/@ember/ordered-set/index.js`)).to.eql({});
+
+    expect(readJSON(`${project.baseDir}/node_modules/ember-cli/node_modules/console-ui/package.json`)).to.eql({
+      name: 'console-ui',
+      version: '3.3.3',
+      keywords: [],
+      dependencies: {},
+      devDependencies: {},
+    });
+
+    expect(nodeModules.sort()).to.eql(['@ember', 'ember-cli', 'ember-source']);
+
+    expect(index).to.eql('module.exports = "Hello, World!";');
+  });
+
+  it('can write a DirJSON', async function () {
+    let project = new Project({
+      name: 'rsvp',
+      version: '3.1.4',
+    });
+
+    await project.write({
+      top: {
+        middle: {
+          bottom: {
+            'foo.js': 'console.log("bar");',
           },
         },
-      });
-
-      expect(walkSync(project.baseDir)).to.eql([
-        'index.js',
-        'package.json',
-        'top/',
-        'top/middle/',
-        'top/middle/bottom/',
-        'top/middle/bottom/foo.js',
-      ]);
+      },
     });
 
-    it('can merge files in the correct order', async function () {
-      let project = new Project({
-        name: 'rsvp',
-        version: '3.1.4',
-        files: {
-          'foo.js': 'console.log("bar");',
-        },
-      });
+    expect(walkSync(project.baseDir)).to.eql([
+      'index.js',
+      'package.json',
+      'top/',
+      'top/middle/',
+      'top/middle/bottom/',
+      'top/middle/bottom/foo.js',
+    ]);
+  });
 
-      expect(project.files).to.eql({
+  it('can merge files in the correct order', async function () {
+    let project = new Project({
+      name: 'rsvp',
+      version: '3.1.4',
+      files: {
         'foo.js': 'console.log("bar");',
-        'index.js': `
+      },
+    });
+
+    expect(project.files).to.eql({
+      'foo.js': 'console.log("bar");',
+      'index.js': `
     'use strict';
      module.exports = {};`,
-      });
+    });
 
-      project.mergeFiles({
-        'bar.js': 'console.log("baz");',
-      });
+    project.mergeFiles({
+      'bar.js': 'console.log("baz");',
+    });
 
-      expect(project.files).to.eql({
-        'foo.js': 'console.log("bar");',
-        'bar.js': 'console.log("baz");',
-        'index.js': `
+    expect(project.files).to.eql({
+      'foo.js': 'console.log("bar");',
+      'bar.js': 'console.log("baz");',
+      'index.js': `
     'use strict';
      module.exports = {};`,
-      });
-    });
-
-    describe('project constructor with callback DSL', function () {
-      it('name, version, cb', async () => {
-        const projects: { [key: string]: Project } = {};
-        const project = new Project('my-project', '0.0.1', project => {
-          projects.default = project;
-          projects.a = project.addDependency('a', '0.0.2', a => {
-            projects.b = a.addDependency('b', '0.0.3');
-          });
-
-          projects.c = project.addDevDependency({ name: 'c', version: '0.0.4' }, a => {
-            projects.d = a.addDevDependency('d', { version: '0.0.5' }, d => {
-              projects.e = d.addDependency('e', { version: '0.0.6' });
-            });
-          });
-        });
-
-        expect(projects.default).to.equal(project);
-        expect(projects.a).to.exist;
-        expect(projects.b).to.exist;
-        expect(projects.c).to.exist;
-        expect(projects.d).to.exist;
-
-        expect(project.version).to.eql('0.0.1');
-        expect(projects.a.version).to.eql('0.0.2');
-        expect(projects.b.version).to.eql('0.0.3');
-        expect(projects.c.version).to.eql('0.0.4');
-        expect(projects.d.version).to.eql('0.0.5');
-        expect(projects.e.version).to.eql('0.0.6');
-      });
-
-      it('ProjectArgs, cb', async () => {
-        const projects: { [key: string]: Project } = {};
-        const project = new Project({ name: 'my-project', version: '0.0.0' }, project => {
-          projects.default = project;
-        });
-
-        expect(project).to.eql(projects.default);
-      });
-
-      it('name, projectArgs - name, cb', async () => {
-        const projects: { [key: string]: Project } = {};
-        const project = new Project({ name: 'my-project', version: '0.0.0' }, project => {
-          projects.default = project;
-        });
-
-        expect(project).to.eql(projects.default);
-      });
-
-      it('name, version, projectArgs - name - version, cb', async () => {
-        const projects: { [key: string]: Project } = {};
-        const project = new Project('my-project', '0.0.0', { files: {} }, project => {
-          projects.default = project;
-        });
-
-        expect(project).to.eql(projects.default);
-      });
-    });
-
-    describe('.pkg', function () {
-      it('flattened usage', async () => {
-        const app = new Project('app', '3.1.1');
-        const rsvp = app.addDependency('rsvp', '3.2.2');
-        const a = rsvp.addDependency('a', '1.1.1');
-
-        expect(app.pkg).to.eql({
-          name: 'app',
-          version: '3.1.1',
-          keywords: [],
-        });
-
-        expect(rsvp.pkg).to.eql({
-          name: 'rsvp',
-          version: '3.2.2',
-          keywords: [],
-        });
-
-        expect(a.pkg).to.eql({
-          name: 'a',
-          version: '1.1.1',
-          keywords: [],
-        });
-
-        await app.write();
-
-        expect(app.pkg).to.eql({
-          name: 'app',
-          version: '3.1.1',
-          keywords: [],
-          dependencies: {
-            rsvp: '3.2.2',
-          },
-          devDependencies: {},
-        });
-
-        expect(rsvp.pkg).to.eql({
-          name: 'rsvp',
-          version: '3.2.2',
-          keywords: [],
-          dependencies: {
-            a: '1.1.1',
-          },
-          devDependencies: {},
-        });
-
-        expect(a.pkg).to.eql({
-          name: 'a',
-          version: '1.1.1',
-          keywords: [],
-          dependencies: {},
-          devDependencies: {},
-        });
-      });
-
-      it('callback usage', async () => {
-        let rsvp!: Project, a!: Project;
-
-        const app = new Project('app', '3.1.1', app => {
-          rsvp = app.addDependency('rsvp', '3.2.2', rsvp => {
-            a = rsvp.addDependency('a', '1.1.1');
-          });
-        });
-
-        expect(app.pkg).to.eql({
-          name: 'app',
-          version: '3.1.1',
-          keywords: [],
-        });
-
-        expect(rsvp.pkg).to.eql({
-          name: 'rsvp',
-          version: '3.2.2',
-          keywords: [],
-        });
-
-        expect(a.pkg).to.eql({
-          name: 'a',
-          version: '1.1.1',
-          keywords: [],
-        });
-
-        await app.write();
-
-        expect(app.pkg).to.eql({
-          name: 'app',
-          version: '3.1.1',
-          keywords: [],
-          dependencies: {
-            rsvp: '3.2.2',
-          },
-          devDependencies: {},
-        });
-
-        expect(rsvp.pkg).to.eql({
-          name: 'rsvp',
-          version: '3.2.2',
-          keywords: [],
-          dependencies: {
-            a: '1.1.1',
-          },
-          devDependencies: {},
-        });
-
-        expect(a.pkg).to.eql({
-          name: 'a',
-          version: '1.1.1',
-          keywords: [],
-          dependencies: {},
-          devDependencies: {},
-        });
-      });
-    });
-
-    it('supports default version', async () => {
-      const input = new Project();
-      expect(input.version).to.eql('0.0.0');
-      await input.write();
-      expect(fs.readJSONSync(path.join(input.baseDir, 'package.json'))).to.have.property('version', '0.0.0');
-    });
-
-    it('supports removing packages', async () => {
-      const input = new Project();
-
-      input.addDependency('rsvp').addDependency();
-      input.addDevDependency('omg').addDependency();
-
-      expect(input.dependencyProjects().map(dep => dep.name)).to.eql(['rsvp']);
-      expect(input.devDependencyProjects().map(dep => dep.name)).to.eql(['omg']);
-
-      input.removeDependency('rsvp');
-      input.removeDevDependency('omg');
-
-      expect(input.dependencyProjects().map(dep => dep.name)).to.eql([]);
-      expect(input.devDependencyProjects().map(dep => dep.name)).to.eql([]);
-    });
-
-    it('it supports deep cloning', async () => {
-      const input = new Project('foo', '3.1.2', {
-        files: {
-          'index.js': 'OMG',
-          foo: {
-            bar: {
-              baz: 'quz',
-            },
-          },
-        },
-      });
-
-      input.addDependency('rsvp', '4.4.4').addDependency('mkdirp', '4.4.4');
-      input.addDevDependency('omg', '4.4.4').addDependency('fs-extra', '5.5.5.');
-
-      const output = input.clone();
-
-      await output.write();
-      await input.write();
-
-      expect(readSync(output.baseDir)).deep.equals(readSync(input.baseDir));
-
-      input.name = 'bar';
-
-      expect(output.name).to.eql('foo');
-      expect(input.name).to.eql('bar');
-
-      input.addDependency('-no-such-package-', '22');
-      expect(input.dependencyProjects().map(x => x.name)).to.contain('-no-such-package-');
-      expect(output.dependencyProjects().map(x => x.name)).to.not.contain('-no-such-package-');
-    });
-
-    it('supports fromDir', async () => {
-      const input = new Project({
-        files: {
-          'index.js': 'OMG',
-          foo: {
-            bar: {
-              baz: 'quz',
-            },
-          },
-        },
-      });
-      input.addDependency('rsvp', '4.4.4').addDependency('mkdirp', '4.4.4');
-      input.addDevDependency('omg', '4.4.4').addDependency('fs-extra', '5.5.5.');
-      await input.write();
-
-      const output = Project.fromDir(input.baseDir);
-
-      expect(output.files).to.eql(input.files);
-      expect(output.dependencyProjects().map(p => p.name)).to.have.members(input.dependencyProjects().map(p => p.name));
-    });
-
-    it('supports inferring package#name if Project.fromDir is invoked without a second argument', async () => {
-      const input = new Project('foo', '3.1.2', {
-        files: {
-          'index.js': 'OMG',
-          foo: {
-            bar: {
-              baz: 'quz',
-            },
-          },
-        },
-      });
-      input.addDependency('rsvp', '4.4.4').addDependency('mkdirp', '4.4.4');
-      input.addDevDependency('omg', '4.4.4').addDependency('fs-extra', '5.5.5.');
-      await input.write();
-
-      const output = Project.fromDir(input.baseDir);
-
-      expect(output.name).to.eql('foo');
-      expect(output.version).to.eql('3.1.2');
-      expect(output.files).to.eql(input.files);
-      expect(output.pkg).to.eql(input.pkg);
-    });
-
-    it('supports custom PKG properties', async () => {
-      let project = new Project('foo', '123');
-      project.pkg['ember-addon'] = {
-        version: 1,
-      };
-
-      await project.write();
-      expect(readJSON(`${project.baseDir}/package.json`)).to.eql({
-        dependencies: {},
-        devDependencies: {},
-        'ember-addon': {
-          version: 1,
-        },
-        keywords: [],
-        name: 'foo',
-        version: '123',
-      });
-
-      project.pkg.name = 'apple';
-      project.pkg.version = '123';
-
-      expect(project.name, 'apple');
-      expect(project.version, '123');
-
-      project.name = 'pink';
-      project.version = '1';
-
-      expect(project.name, 'pink');
-      expect(project.version, '1');
-
-      expect(project.pkg.name, 'pink');
-      expect(project.pkg.version, '1');
-    });
-
-    it('handles scoped deps', async () => {
-      let project = new Project('foo', '123');
-      project.addDependency('@test/foo', '1.0.0');
-      project.addDependency('@test/bar', '1.0.0');
-      await project.write();
-      expect(fs.readdirSync(path.join(project.baseDir, 'node_modules', '@test'))).to.have.members(['foo', 'bar']);
-    });
-
-    it('handles scoped devDeps', async () => {
-      let project = new Project('foo', '123');
-      project.addDevDependency('@test/foo', '1.0.0');
-      project.addDevDependency('@test/bar', '1.0.0');
-      await project.write();
-      expect(fs.readdirSync(path.join(project.baseDir, 'node_modules', '@test'))).to.have.members(['foo', 'bar']);
-    });
-
-    it('has a working dispose to allow early cleanup', async () => {
-      let project = new Project('foo', '123');
-      project.addDependency('rsvp', '1.2.3');
-      project.addDevDependency('q', '1.2.4');
-      await project.write();
-      expect(fs.existsSync(project.baseDir)).to.eql(true);
-      project.dispose();
-      expect(fs.existsSync(project.baseDir)).to.eql(false);
-    });
-
-    it('supports linking to existing dependency via baseDir', async () => {
-      let baseProject = new Project('base');
-      baseProject.addDependency('moment');
-      await baseProject.write();
-
-      let project = new Project('my-app');
-      project.linkDependency('moment', { baseDir: baseProject.baseDir });
-      await project.write();
-      expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'moment'))).to.eql(
-        path.join(baseProject.baseDir, 'node_modules', 'moment')
-      );
-    });
-
-    it('supports linking to existing dependency via baseDir and resolveName', async () => {
-      let baseProject = new Project('base');
-      baseProject.addDependency('moment-x');
-      await baseProject.write();
-
-      let project = new Project('my-app');
-      project.linkDependency('moment', { baseDir: baseProject.baseDir, resolveName: 'moment-x' });
-      await project.write();
-      expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'moment'))).to.eql(
-        path.join(baseProject.baseDir, 'node_modules', 'moment-x')
-      );
-    });
-
-    it('supports linking to existing dependency via target', async () => {
-      let baseProject = new Project('base');
-      await baseProject.write();
-
-      let project = new Project('my-app');
-      project.linkDependency('moment', { target: baseProject.baseDir });
-      await project.write();
-      expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'moment'))).to.eql(baseProject.baseDir);
-    });
-
-    it('supports linking between dependencies', async () => {
-      let project = new Project('my-app');
-      let depA = project.addDependency('dep-a');
-      let depB = project.addDependency('dep-b');
-      let depC = project.addDependency('dep-c');
-      depB.linkDependency('dep-a', { project: depA });
-      depB.linkDependency('dep-c', { project: depC });
-      await project.write();
-      expect(fs.readlinkSync(path.join(depB.baseDir, 'node_modules', 'dep-a'))).to.eql(depA.baseDir);
-      expect(fs.readlinkSync(path.join(depB.baseDir, 'node_modules', 'dep-c'))).to.eql(depC.baseDir);
-    });
-
-    it('supports linking to existing dependency from within nested project', async () => {
-      let baseProject = new Project('base');
-      baseProject.addDependency('moment');
-      await baseProject.write();
-      let project = new Project('my-app');
-      let inner = project.addDependency('inner');
-      inner.linkDependency('moment', { baseDir: baseProject.baseDir });
-      await project.write();
-      expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'inner', 'node_modules', 'moment'))).to.eql(
-        path.join(baseProject.baseDir, 'node_modules', 'moment')
-      );
-    });
-
-    it('adjusts peerDependencies of linked dependencies', async () => {
-      let baseProject = new Project('base');
-      let alpha = baseProject.addDependency('alpha', {
-        files: {
-          'index.js': `
-            exports.betaVersion = function() {
-              return require('beta/package.json').version;
-            }
-            exports.gammaLocation = function() {
-              return require.resolve('gamma/package.json');
-            }
-          `,
-          deeper: {
-            'index.js': `
-              exports.betaVersion = function() {
-                return 'inner' + require('beta/package.json').version;
-              }
-            `,
-          },
-        },
-      });
-      alpha.pkg.peerDependencies = { beta: '^1.0.0' };
-      alpha.addDependency('gamma');
-      baseProject.addDependency('beta', { version: '1.1.0' });
-      await baseProject.write();
-
-      // precondition: in the baseProject, alpha sees its beta peerDep as beta@1.1.0
-      expect(require(require.resolve('alpha', { paths: [baseProject.baseDir] })).betaVersion()).to.eql('1.1.0');
-
-      let project = new Project('my-app');
-      project.linkDependency('alpha', { baseDir: baseProject.baseDir });
-      project.addDependency('beta', { version: '1.2.0' });
-      await project.write();
-
-      // in our linked project, alpha sees its beta peerDep as beta@1.2.0
-      expect(require(require.resolve('alpha', { paths: [project.baseDir] })).betaVersion()).to.eql('1.2.0');
-
-      // deeper modules in our package also work correctly
-      expect(require(require.resolve('alpha/deeper', { paths: [project.baseDir] })).betaVersion()).to.eql('inner1.2.0');
-
-      // unrelated dependencies are still shared
-      expect(require(require.resolve('alpha', { paths: [project.baseDir] })).gammaLocation()).to.eql(
-        require(require.resolve('alpha', { paths: [baseProject.baseDir] })).gammaLocation()
-      );
-    });
-
-    it('adjusts deeply nested peerDependencies of linked dependencies', async () => {
-      let baseProject = new Project('base', {
-        files: {
-          'index.js': `
-            exports.alphasBetaVersion = function() {
-              return require('alpha').betaVersion();
-            }
-            exports.gammasBetaVersion = function() {
-              return require('alpha').gammasBetaVersion();
-            }
-          `,
-        },
-      });
-
-      // alpha is a direct dependency of base and has a peer dep on beta
-      let alpha = baseProject.addDependency('alpha', {
-        files: {
-          'index.js': `
-            exports.betaVersion = function() {
-              return require('beta/package.json').version;
-            }
-            exports.gammasBetaVersion = function() {
-              return require('gamma').betaVersion();
-            }
-          `,
-        },
-      });
-      alpha.pkg.peerDependencies = { beta: '^1.0.0' };
-
-      // gamma is a direct dependency of alpha and shares the peer dep on beta
-      let gamma = alpha.addDependency('gamma', {
-        files: {
-          'index.js': `
-            exports.betaVersion = function() {
-              return require('beta/package.json').version;
-            }
-          `,
-        },
-      });
-      gamma.pkg.peerDependencies = { beta: '^1.0.0' };
-      baseProject.addDependency('beta', { version: '1.1.0' });
-      await baseProject.write();
-
-      // precondition: in the baseProject, alpha and gamma sees their beta peerDep as beta@1.1.0
-      let baseModule = require(baseProject.baseDir);
-      expect(baseModule.alphasBetaVersion()).to.eql('1.1.0');
-      expect(baseModule.gammasBetaVersion()).to.eql('1.1.0');
-
-      let project = new Project('my-app', {
-        files: {
-          'index.js': `
-            exports.alphasBetaVersion = function() {
-              return require('alpha').betaVersion();
-            }
-            exports.gammasBetaVersion = function() {
-              return require('alpha').gammasBetaVersion();
-            }
-        `,
-        },
-      });
-      project.linkDependency('alpha', { baseDir: baseProject.baseDir });
-      project.addDependency('beta', { version: '1.2.0' });
-      await project.write();
-
-      let myAppModule = require(project.baseDir);
-      expect(myAppModule.alphasBetaVersion()).to.eql('1.2.0');
-      expect(myAppModule.gammasBetaVersion()).to.eql('1.2.0');
-    });
-
-    it('adds linked dependencies to package.json', async () => {
-      let baseProject = new Project('base');
-      baseProject.addDependency('moment', '1.2.3');
-      await baseProject.write();
-
-      let project = new Project('my-app');
-      project.linkDependency('moment', { baseDir: baseProject.baseDir });
-      await project.write();
-      expect(fs.readJSONSync(path.join(project.baseDir, 'package.json')).dependencies.moment).to.eql('1.2.3');
-    });
-
-    it('adds linked devDependencies to package.json', async () => {
-      let baseProject = new Project('base');
-      baseProject.addDependency('moment', '1.2.3');
-      await baseProject.write();
-
-      let project = new Project('my-app');
-      project.linkDevDependency('moment', { baseDir: baseProject.baseDir });
-      await project.write();
-      expect(fs.readJSONSync(path.join(project.baseDir, 'package.json')).devDependencies.moment).to.eql('1.2.3');
-    });
-
-    it('supports linking to existing devDependencies', async () => {
-      let baseProject = new Project('base');
-      baseProject.addDependency('moment', '1.2.3');
-      await baseProject.write();
-
-      let project = new Project('my-app');
-      project.linkDevDependency('moment', { baseDir: baseProject.baseDir });
-      await project.write();
-      expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'moment'))).to.eql(
-        path.join(baseProject.baseDir, 'node_modules', 'moment')
-      );
-    });
-
-    it('can read a project with linked dependencies', async () => {
-      // start with a template addon
-      let addonTemplate = new Project('stock-addon');
-      addonTemplate.addDependency('helper-lib', '1.2.3');
-      addonTemplate.addDevDependency('test-lib');
-      addonTemplate.files['hello.js'] = '// it works';
-      await addonTemplate.write();
-
-      // build a new addon from the template
-      let myAddon = Project.fromDir(addonTemplate.baseDir, { linkDeps: true });
-      myAddon.name = 'custom-addon';
-      myAddon.files['layered-extra.js'] = '// extra stuff';
-
-      // use the new addon in an app
-      let myApp = new Project('my-app');
-      myApp.addDependency(myAddon);
-      await myApp.write();
-
-      expect(
-        fs.readlinkSync(path.join(myApp.baseDir, 'node_modules', 'custom-addon', 'node_modules', 'helper-lib'))
-      ).to.eql(path.join(addonTemplate.baseDir, 'node_modules', 'helper-lib'));
-
-      // dev dependencies not included by default
-      expect(
-        fs.existsSync(path.join(myApp.baseDir, 'node_modules', 'custom-addon', 'node_modules', 'test-lib'))
-      ).to.eql(false);
-
-      expect(fs.existsSync(path.join(myApp.baseDir, 'node_modules', 'custom-addon', 'hello.js'))).to.eql(true);
-      expect(fs.existsSync(path.join(myApp.baseDir, 'node_modules', 'custom-addon', 'layered-extra.js'))).to.eql(true);
-    });
-
-    it('throws an error for linked deps when version is missing', async () => {
-      let template = new Project('template');
-      template.addDependency('local-lib', './local-lib');
-      template.mergeFiles({
-        'local-lib': {
-          'package.json': JSON.stringify({
-            name: 'local-lib',
-            main: 'index.js',
-          }),
-          'index.js': 'console.log("hello world");',
-        },
-      });
-
-      await template.write();
-
-      let localLibPkgPath = path.join(template.baseDir, 'node_modules', 'local-lib', 'package.json');
-
-      let localLibPkgJson = await fs.readJSON(localLibPkgPath);
-      // we have to manually remove the version from the package.json bc fixturify automatically adds it
-      // when calling `addDependency`
-      delete localLibPkgJson.version;
-      await fs.writeJSON(localLibPkgPath, localLibPkgJson);
-
-      let app = Project.fromDir(template.baseDir, { linkDeps: true });
-      await expect(app.write()).rejects.toThrowError(
-        'No version found for package local-lib. All dependencies must have both a name and version in their package.json.'
-      );
-
-      template.dispose();
-      app.dispose();
-    });
-
-    it('can read a project with linked dev dependencies', async () => {
-      // start with a template app
-      let appTemplate = new Project('stock-app');
-      appTemplate.addDependency('helper-lib', '1.2.3');
-      appTemplate.addDevDependency('test-lib');
-      appTemplate.files['hello.js'] = '// it works';
-      await appTemplate.write();
-
-      // build a new addon from the template
-      let myApp = Project.fromDir(appTemplate.baseDir, { linkDevDeps: true });
-      myApp.name = 'custom-addon';
-      myApp.files['layered-extra.js'] = '// extra stuff';
-      await myApp.write();
-
-      expect(fs.readlinkSync(path.join(myApp.baseDir, 'node_modules', 'helper-lib'))).to.eql(
-        path.join(appTemplate.baseDir, 'node_modules', 'helper-lib')
-      );
-
-      expect(fs.readlinkSync(path.join(myApp.baseDir, 'node_modules', 'test-lib'))).to.eql(
-        path.join(appTemplate.baseDir, 'node_modules', 'test-lib')
-      );
-
-      expect(fs.existsSync(path.join(myApp.baseDir, 'hello.js'))).to.eql(true);
-      expect(fs.existsSync(path.join(myApp.baseDir, 'layered-extra.js'))).to.eql(true);
-    });
-
-    it('can override a linked dependency with a new Project dependency', async () => {
-      let baseProject = new Project('base');
-      baseProject.addDependency('moment', '1.2.3');
-      await baseProject.write();
-
-      let project = Project.fromDir(baseProject.baseDir, { linkDeps: true });
-      project.addDependency('moment', '4.5.6');
-      await project.write();
-      expect(fs.lstatSync(path.join(project.baseDir, 'node_modules', 'moment')).isSymbolicLink()).to.eql(false);
-      expect(fs.readJSONSync(path.join(project.baseDir, 'node_modules', 'moment', 'package.json')).version).to.eql(
-        '4.5.6'
-      );
-    });
-
-    it('can override a Project dependency with a linked dependency', async () => {
-      let dep = new Project('dep', '1.2.3');
-      dep.files['first.js'] = '';
-      await dep.write();
-
-      let project = new Project('app');
-      let dep2 = project.addDependency('dep', '4.5.6');
-      dep2.files['second.js'] = '';
-      project.linkDependency('dep', { target: dep.baseDir });
-      await project.write();
-      expect(fs.lstatSync(path.join(project.baseDir, 'node_modules', 'dep')).isSymbolicLink(), 'is symlink').is.true;
-      expect(
-        fs.readJSONSync(path.join(project.baseDir, 'node_modules', 'dep', 'package.json')).version,
-        'version'
-      ).to.eql('1.2.3');
-      expect(fs.existsSync(path.join(project.baseDir, 'node_modules', 'dep', 'first.js')), 'first.js').is.true;
-      expect(fs.existsSync(path.join(project.baseDir, 'node_modules', 'dep', 'second.js')), 'second.js').is.false;
-    });
-
-    it('can remove a linked dependency', async () => {
-      let dep = new Project('dep', '1.2.3');
-      dep.files['first.js'] = '';
-      await dep.write();
-
-      let project = new Project('app');
-      project.linkDependency('dep', { target: dep.baseDir });
-      project.removeDependency('dep');
-      await project.write();
-      expect(fs.readJSONSync(path.join(project.baseDir, 'package.json')).dependencies?.dep).to.be.undefined;
-      expect(fs.existsSync(path.join(project.baseDir, 'node_modules', 'dep'))).is.false;
-    });
-
-    it('preserves linking behaviors through clone', async () => {
-      let baseProject = new Project('base');
-      await baseProject.write();
-
-      let project = new Project('my-app');
-      project.linkDependency('moment', { target: baseProject.baseDir });
-      let cloned = project.clone();
-      await cloned.write();
-      expect(fs.readlinkSync(path.join(cloned.baseDir, 'node_modules', 'moment'))).to.eql(baseProject.baseDir);
-    });
-
-    it('can choose the requested semver range of a dependency', async () => {
-      let proj = new Project();
-      proj.addDependency('mylib', { version: '1.2.3', requestedRange: '^1' });
-      await proj.write();
-      expect(fs.readJSONSync(path.join(proj.baseDir, 'package.json')).dependencies.mylib).to.eql('^1');
-    });
-
-    it('can choose the requested semver range of a linked dependency', async () => {
-      let baseProject = new Project('moment', '1.2.3');
-      await baseProject.write();
-
-      let project = new Project('my-app');
-      project.linkDependency('moment', { target: baseProject.baseDir, requestedRange: '^1' });
-      await project.write();
-      expect(fs.readJSONSync(path.join(project.baseDir, 'package.json')).dependencies.moment).to.eql('^1');
-    });
-
-    it('links bin entry in package', async () => {
-      let project = new Project('my-app', '1.0.0');
-      project.pkg['license'] = 'MIT';
-
-      project.addDependency({
-        files: {
-          'package.json': JSON.stringify({
-            name: 'my-cli',
-            version: '1.0.0',
-            bin: { hello: 'hello.js', goodbye: 'goodbye.js' },
-          }),
-          'hello.js': `#!/usr/bin/env node
-          require("./index.js")("hello")`,
-          'goodbye.js': `#!/usr/bin/env node
-          require("./index.js")("goodbye")`,
-          'index.js': `module.exports = (s) => console.log(s)`,
-        },
-      });
-
-      await project.write();
-
-      const { execFileSync } = require('child_process');
-
-      expect(
-        execFileSync('yarn', ['-s', 'run', 'hello'], {
-          cwd: project.baseDir,
-          encoding: 'utf8',
-        })
-      ).to.eql('hello\n');
-
-      const binPath = execFileSync('yarn', ['bin'], {
-        cwd: project.baseDir,
-        encoding: 'utf8',
-      }).trimEnd();
-
-      expect(execFileSync(path.join(binPath, 'goodbye'), { encoding: 'utf8' })).to.eql('goodbye\n');
-    });
-
-    it('should not share files', function () {
-      let project1 = new Project('my-app', '1.0.0');
-      project1.files['foo.js'] = 'foo';
-
-      let project2 = new Project('my-app', '1.0.0');
-
-      expect(project2.files['foo.js']).to.be.undefined;
     });
   });
-}
+
+  describe('project constructor with callback DSL', function () {
+    it('name, version, cb', async () => {
+      const projects: { [key: string]: Project } = {};
+      const project = new Project('my-project', '0.0.1', project => {
+        projects.default = project;
+        projects.a = project.addDependency('a', '0.0.2', a => {
+          projects.b = a.addDependency('b', '0.0.3');
+        });
+
+        projects.c = project.addDevDependency({ name: 'c', version: '0.0.4' }, a => {
+          projects.d = a.addDevDependency('d', { version: '0.0.5' }, d => {
+            projects.e = d.addDependency('e', { version: '0.0.6' });
+          });
+        });
+      });
+
+      expect(projects.default).to.equal(project);
+      expect(projects.a).to.exist;
+      expect(projects.b).to.exist;
+      expect(projects.c).to.exist;
+      expect(projects.d).to.exist;
+
+      expect(project.version).to.eql('0.0.1');
+      expect(projects.a.version).to.eql('0.0.2');
+      expect(projects.b.version).to.eql('0.0.3');
+      expect(projects.c.version).to.eql('0.0.4');
+      expect(projects.d.version).to.eql('0.0.5');
+      expect(projects.e.version).to.eql('0.0.6');
+    });
+
+    it('ProjectArgs, cb', async () => {
+      const projects: { [key: string]: Project } = {};
+      const project = new Project({ name: 'my-project', version: '0.0.0' }, project => {
+        projects.default = project;
+      });
+
+      expect(project).to.eql(projects.default);
+    });
+
+    it('name, projectArgs - name, cb', async () => {
+      const projects: { [key: string]: Project } = {};
+      const project = new Project({ name: 'my-project', version: '0.0.0' }, project => {
+        projects.default = project;
+      });
+
+      expect(project).to.eql(projects.default);
+    });
+
+    it('name, version, projectArgs - name - version, cb', async () => {
+      const projects: { [key: string]: Project } = {};
+      const project = new Project('my-project', '0.0.0', { files: {} }, project => {
+        projects.default = project;
+      });
+
+      expect(project).to.eql(projects.default);
+    });
+  });
+
+  describe('.pkg', function () {
+    it('flattened usage', async () => {
+      const app = new Project('app', '3.1.1');
+      const rsvp = app.addDependency('rsvp', '3.2.2');
+      const a = rsvp.addDependency('a', '1.1.1');
+
+      expect(app.pkg).to.eql({
+        name: 'app',
+        version: '3.1.1',
+        keywords: [],
+      });
+
+      expect(rsvp.pkg).to.eql({
+        name: 'rsvp',
+        version: '3.2.2',
+        keywords: [],
+      });
+
+      expect(a.pkg).to.eql({
+        name: 'a',
+        version: '1.1.1',
+        keywords: [],
+      });
+
+      await app.write();
+
+      expect(app.pkg).to.eql({
+        name: 'app',
+        version: '3.1.1',
+        keywords: [],
+        dependencies: {
+          rsvp: '3.2.2',
+        },
+        devDependencies: {},
+      });
+
+      expect(rsvp.pkg).to.eql({
+        name: 'rsvp',
+        version: '3.2.2',
+        keywords: [],
+        dependencies: {
+          a: '1.1.1',
+        },
+        devDependencies: {},
+      });
+
+      expect(a.pkg).to.eql({
+        name: 'a',
+        version: '1.1.1',
+        keywords: [],
+        dependencies: {},
+        devDependencies: {},
+      });
+    });
+
+    it('callback usage', async () => {
+      let rsvp!: Project, a!: Project;
+
+      const app = new Project('app', '3.1.1', app => {
+        rsvp = app.addDependency('rsvp', '3.2.2', rsvp => {
+          a = rsvp.addDependency('a', '1.1.1');
+        });
+      });
+
+      expect(app.pkg).to.eql({
+        name: 'app',
+        version: '3.1.1',
+        keywords: [],
+      });
+
+      expect(rsvp.pkg).to.eql({
+        name: 'rsvp',
+        version: '3.2.2',
+        keywords: [],
+      });
+
+      expect(a.pkg).to.eql({
+        name: 'a',
+        version: '1.1.1',
+        keywords: [],
+      });
+
+      await app.write();
+
+      expect(app.pkg).to.eql({
+        name: 'app',
+        version: '3.1.1',
+        keywords: [],
+        dependencies: {
+          rsvp: '3.2.2',
+        },
+        devDependencies: {},
+      });
+
+      expect(rsvp.pkg).to.eql({
+        name: 'rsvp',
+        version: '3.2.2',
+        keywords: [],
+        dependencies: {
+          a: '1.1.1',
+        },
+        devDependencies: {},
+      });
+
+      expect(a.pkg).to.eql({
+        name: 'a',
+        version: '1.1.1',
+        keywords: [],
+        dependencies: {},
+        devDependencies: {},
+      });
+    });
+  });
+
+  it('supports default version', async () => {
+    const input = new Project();
+    expect(input.version).to.eql('0.0.0');
+    await input.write();
+    expect(fs.readJSONSync(path.join(input.baseDir, 'package.json'))).to.have.property('version', '0.0.0');
+  });
+
+  it('supports removing packages', async () => {
+    const input = new Project();
+
+    input.addDependency('rsvp').addDependency();
+    input.addDevDependency('omg').addDependency();
+
+    expect(input.dependencyProjects().map(dep => dep.name)).to.eql(['rsvp']);
+    expect(input.devDependencyProjects().map(dep => dep.name)).to.eql(['omg']);
+
+    input.removeDependency('rsvp');
+    input.removeDevDependency('omg');
+
+    expect(input.dependencyProjects().map(dep => dep.name)).to.eql([]);
+    expect(input.devDependencyProjects().map(dep => dep.name)).to.eql([]);
+  });
+
+  it('it supports deep cloning', async () => {
+    const input = new Project('foo', '3.1.2', {
+      files: {
+        'index.js': 'OMG',
+        foo: {
+          bar: {
+            baz: 'quz',
+          },
+        },
+      },
+    });
+
+    input.addDependency('rsvp', '4.4.4').addDependency('mkdirp', '4.4.4');
+    input.addDevDependency('omg', '4.4.4').addDependency('fs-extra', '5.5.5.');
+
+    const output = input.clone();
+
+    await output.write();
+    await input.write();
+
+    expect(readSync(output.baseDir)).deep.equals(readSync(input.baseDir));
+
+    input.name = 'bar';
+
+    expect(output.name).to.eql('foo');
+    expect(input.name).to.eql('bar');
+
+    input.addDependency('-no-such-package-', '22');
+    expect(input.dependencyProjects().map(x => x.name)).to.contain('-no-such-package-');
+    expect(output.dependencyProjects().map(x => x.name)).to.not.contain('-no-such-package-');
+  });
+
+  it('supports fromDir', async () => {
+    const input = new Project({
+      files: {
+        'index.js': 'OMG',
+        foo: {
+          bar: {
+            baz: 'quz',
+          },
+        },
+      },
+    });
+    input.addDependency('rsvp', '4.4.4').addDependency('mkdirp', '4.4.4');
+    input.addDevDependency('omg', '4.4.4').addDependency('fs-extra', '5.5.5.');
+    await input.write();
+
+    const output = Project.fromDir(input.baseDir);
+
+    expect(output.files).to.eql(input.files);
+    expect(output.dependencyProjects().map(p => p.name)).to.have.members(input.dependencyProjects().map(p => p.name));
+  });
+
+  it('supports inferring package#name if Project.fromDir is invoked without a second argument', async () => {
+    const input = new Project('foo', '3.1.2', {
+      files: {
+        'index.js': 'OMG',
+        foo: {
+          bar: {
+            baz: 'quz',
+          },
+        },
+      },
+    });
+    input.addDependency('rsvp', '4.4.4').addDependency('mkdirp', '4.4.4');
+    input.addDevDependency('omg', '4.4.4').addDependency('fs-extra', '5.5.5.');
+    await input.write();
+
+    const output = Project.fromDir(input.baseDir);
+
+    expect(output.name).to.eql('foo');
+    expect(output.version).to.eql('3.1.2');
+    expect(output.files).to.eql(input.files);
+    expect(output.pkg).to.eql(input.pkg);
+  });
+
+  it('supports custom PKG properties', async () => {
+    let project = new Project('foo', '123');
+    project.pkg['ember-addon'] = {
+      version: 1,
+    };
+
+    await project.write();
+    expect(readJSON(`${project.baseDir}/package.json`)).to.eql({
+      dependencies: {},
+      devDependencies: {},
+      'ember-addon': {
+        version: 1,
+      },
+      keywords: [],
+      name: 'foo',
+      version: '123',
+    });
+
+    project.pkg.name = 'apple';
+    project.pkg.version = '123';
+
+    expect(project.name, 'apple');
+    expect(project.version, '123');
+
+    project.name = 'pink';
+    project.version = '1';
+
+    expect(project.name, 'pink');
+    expect(project.version, '1');
+
+    expect(project.pkg.name, 'pink');
+    expect(project.pkg.version, '1');
+  });
+
+  it('handles scoped deps', async () => {
+    let project = new Project('foo', '123');
+    project.addDependency('@test/foo', '1.0.0');
+    project.addDependency('@test/bar', '1.0.0');
+    await project.write();
+    expect(fs.readdirSync(path.join(project.baseDir, 'node_modules', '@test'))).to.have.members(['foo', 'bar']);
+  });
+
+  it('handles scoped devDeps', async () => {
+    let project = new Project('foo', '123');
+    project.addDevDependency('@test/foo', '1.0.0');
+    project.addDevDependency('@test/bar', '1.0.0');
+    await project.write();
+    expect(fs.readdirSync(path.join(project.baseDir, 'node_modules', '@test'))).to.have.members(['foo', 'bar']);
+  });
+
+  it('has a working dispose to allow early cleanup', async () => {
+    let project = new Project('foo', '123');
+    project.addDependency('rsvp', '1.2.3');
+    project.addDevDependency('q', '1.2.4');
+    await project.write();
+    expect(fs.existsSync(project.baseDir)).to.eql(true);
+    project.dispose();
+    expect(fs.existsSync(project.baseDir)).to.eql(false);
+  });
+
+  it('supports linking to existing dependency via baseDir', async () => {
+    let baseProject = new Project('base');
+    baseProject.addDependency('moment');
+    await baseProject.write();
+
+    let project = new Project('my-app');
+    project.linkDependency('moment', { baseDir: baseProject.baseDir });
+    await project.write();
+    expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'moment'))).to.eql(
+      path.join(baseProject.baseDir, 'node_modules', 'moment')
+    );
+  });
+
+  it('supports linking to existing dependency via baseDir and resolveName', async () => {
+    let baseProject = new Project('base');
+    baseProject.addDependency('moment-x');
+    await baseProject.write();
+
+    let project = new Project('my-app');
+    project.linkDependency('moment', { baseDir: baseProject.baseDir, resolveName: 'moment-x' });
+    await project.write();
+    expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'moment'))).to.eql(
+      path.join(baseProject.baseDir, 'node_modules', 'moment-x')
+    );
+  });
+
+  it('supports linking to existing dependency via target', async () => {
+    let baseProject = new Project('base');
+    await baseProject.write();
+
+    let project = new Project('my-app');
+    project.linkDependency('moment', { target: baseProject.baseDir });
+    await project.write();
+    expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'moment'))).to.eql(baseProject.baseDir);
+  });
+
+  it('supports linking between dependencies', async () => {
+    let project = new Project('my-app');
+    let depA = project.addDependency('dep-a');
+    let depB = project.addDependency('dep-b');
+    let depC = project.addDependency('dep-c');
+    depB.linkDependency('dep-a', { project: depA });
+    depB.linkDependency('dep-c', { project: depC });
+    await project.write();
+    expect(fs.readlinkSync(path.join(depB.baseDir, 'node_modules', 'dep-a'))).to.eql(depA.baseDir);
+    expect(fs.readlinkSync(path.join(depB.baseDir, 'node_modules', 'dep-c'))).to.eql(depC.baseDir);
+  });
+
+  it('supports linking to existing dependency from within nested project', async () => {
+    let baseProject = new Project('base');
+    baseProject.addDependency('moment');
+    await baseProject.write();
+    let project = new Project('my-app');
+    let inner = project.addDependency('inner');
+    inner.linkDependency('moment', { baseDir: baseProject.baseDir });
+    await project.write();
+    expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'inner', 'node_modules', 'moment'))).to.eql(
+      path.join(baseProject.baseDir, 'node_modules', 'moment')
+    );
+  });
+
+  it('adjusts peerDependencies of linked dependencies', async () => {
+    let baseProject = new Project('base');
+    let alpha = baseProject.addDependency('alpha', {
+      files: {
+        'index.js': `
+          exports.betaVersion = function() {
+            return require('beta/package.json').version;
+          }
+          exports.gammaLocation = function() {
+            return require.resolve('gamma/package.json');
+          }
+        `,
+        deeper: {
+          'index.js': `
+            exports.betaVersion = function() {
+              return 'inner' + require('beta/package.json').version;
+            }
+          `,
+        },
+      },
+    });
+    alpha.pkg.peerDependencies = { beta: '^1.0.0' };
+    alpha.addDependency('gamma');
+    baseProject.addDependency('beta', { version: '1.1.0' });
+    await baseProject.write();
+
+    // precondition: in the baseProject, alpha sees its beta peerDep as beta@1.1.0
+    expect(require(require.resolve('alpha', { paths: [baseProject.baseDir] })).betaVersion()).to.eql('1.1.0');
+
+    let project = new Project('my-app');
+    project.linkDependency('alpha', { baseDir: baseProject.baseDir });
+    project.addDependency('beta', { version: '1.2.0' });
+    await project.write();
+
+    // in our linked project, alpha sees its beta peerDep as beta@1.2.0
+    expect(require(require.resolve('alpha', { paths: [project.baseDir] })).betaVersion()).to.eql('1.2.0');
+
+    // deeper modules in our package also work correctly
+    expect(require(require.resolve('alpha/deeper', { paths: [project.baseDir] })).betaVersion()).to.eql('inner1.2.0');
+
+    // unrelated dependencies are still shared
+    expect(require(require.resolve('alpha', { paths: [project.baseDir] })).gammaLocation()).to.eql(
+      require(require.resolve('alpha', { paths: [baseProject.baseDir] })).gammaLocation()
+    );
+  });
+
+  it('adjusts deeply nested peerDependencies of linked dependencies', async () => {
+    let baseProject = new Project('base', {
+      files: {
+        'index.js': `
+          exports.alphasBetaVersion = function() {
+            return require('alpha').betaVersion();
+          }
+          exports.gammasBetaVersion = function() {
+            return require('alpha').gammasBetaVersion();
+          }
+        `,
+      },
+    });
+
+    // alpha is a direct dependency of base and has a peer dep on beta
+    let alpha = baseProject.addDependency('alpha', {
+      files: {
+        'index.js': `
+          exports.betaVersion = function() {
+            return require('beta/package.json').version;
+          }
+          exports.gammasBetaVersion = function() {
+            return require('gamma').betaVersion();
+          }
+        `,
+      },
+    });
+    alpha.pkg.peerDependencies = { beta: '^1.0.0' };
+
+    // gamma is a direct dependency of alpha and shares the peer dep on beta
+    let gamma = alpha.addDependency('gamma', {
+      files: {
+        'index.js': `
+          exports.betaVersion = function() {
+            return require('beta/package.json').version;
+          }
+        `,
+      },
+    });
+    gamma.pkg.peerDependencies = { beta: '^1.0.0' };
+    baseProject.addDependency('beta', { version: '1.1.0' });
+    await baseProject.write();
+
+    // precondition: in the baseProject, alpha and gamma sees their beta peerDep as beta@1.1.0
+    let baseModule = require(baseProject.baseDir);
+    expect(baseModule.alphasBetaVersion()).to.eql('1.1.0');
+    expect(baseModule.gammasBetaVersion()).to.eql('1.1.0');
+
+    let project = new Project('my-app', {
+      files: {
+        'index.js': `
+          exports.alphasBetaVersion = function() {
+            return require('alpha').betaVersion();
+          }
+          exports.gammasBetaVersion = function() {
+            return require('alpha').gammasBetaVersion();
+          }
+      `,
+      },
+    });
+    project.linkDependency('alpha', { baseDir: baseProject.baseDir });
+    project.addDependency('beta', { version: '1.2.0' });
+    await project.write();
+
+    let myAppModule = require(project.baseDir);
+    expect(myAppModule.alphasBetaVersion()).to.eql('1.2.0');
+    expect(myAppModule.gammasBetaVersion()).to.eql('1.2.0');
+  });
+
+  it('adds linked dependencies to package.json', async () => {
+    let baseProject = new Project('base');
+    baseProject.addDependency('moment', '1.2.3');
+    await baseProject.write();
+
+    let project = new Project('my-app');
+    project.linkDependency('moment', { baseDir: baseProject.baseDir });
+    await project.write();
+    expect(fs.readJSONSync(path.join(project.baseDir, 'package.json')).dependencies.moment).to.eql('1.2.3');
+  });
+
+  it('adds linked devDependencies to package.json', async () => {
+    let baseProject = new Project('base');
+    baseProject.addDependency('moment', '1.2.3');
+    await baseProject.write();
+
+    let project = new Project('my-app');
+    project.linkDevDependency('moment', { baseDir: baseProject.baseDir });
+    await project.write();
+    expect(fs.readJSONSync(path.join(project.baseDir, 'package.json')).devDependencies.moment).to.eql('1.2.3');
+  });
+
+  it('supports linking to existing devDependencies', async () => {
+    let baseProject = new Project('base');
+    baseProject.addDependency('moment', '1.2.3');
+    await baseProject.write();
+
+    let project = new Project('my-app');
+    project.linkDevDependency('moment', { baseDir: baseProject.baseDir });
+    await project.write();
+    expect(fs.readlinkSync(path.join(project.baseDir, 'node_modules', 'moment'))).to.eql(
+      path.join(baseProject.baseDir, 'node_modules', 'moment')
+    );
+  });
+
+  it('can read a project with linked dependencies', async () => {
+    // start with a template addon
+    let addonTemplate = new Project('stock-addon');
+    addonTemplate.addDependency('helper-lib', '1.2.3');
+    addonTemplate.addDevDependency('test-lib');
+    addonTemplate.files['hello.js'] = '// it works';
+    await addonTemplate.write();
+
+    // build a new addon from the template
+    let myAddon = Project.fromDir(addonTemplate.baseDir, { linkDeps: true });
+    myAddon.name = 'custom-addon';
+    myAddon.files['layered-extra.js'] = '// extra stuff';
+
+    // use the new addon in an app
+    let myApp = new Project('my-app');
+    myApp.addDependency(myAddon);
+    await myApp.write();
+
+    expect(
+      fs.readlinkSync(path.join(myApp.baseDir, 'node_modules', 'custom-addon', 'node_modules', 'helper-lib'))
+    ).to.eql(path.join(addonTemplate.baseDir, 'node_modules', 'helper-lib'));
+
+    // dev dependencies not included by default
+    expect(fs.existsSync(path.join(myApp.baseDir, 'node_modules', 'custom-addon', 'node_modules', 'test-lib'))).to.eql(
+      false
+    );
+
+    expect(fs.existsSync(path.join(myApp.baseDir, 'node_modules', 'custom-addon', 'hello.js'))).to.eql(true);
+    expect(fs.existsSync(path.join(myApp.baseDir, 'node_modules', 'custom-addon', 'layered-extra.js'))).to.eql(true);
+  });
+
+  it('throws an error for linked deps when version is missing', async () => {
+    let template = new Project('template');
+    template.addDependency('local-lib', './local-lib');
+    template.mergeFiles({
+      'local-lib': {
+        'package.json': JSON.stringify({
+          name: 'local-lib',
+          main: 'index.js',
+        }),
+        'index.js': 'console.log("hello world");',
+      },
+    });
+
+    await template.write();
+
+    let localLibPkgPath = path.join(template.baseDir, 'node_modules', 'local-lib', 'package.json');
+
+    let localLibPkgJson = await fs.readJSON(localLibPkgPath);
+    // we have to manually remove the version from the package.json bc fixturify automatically adds it
+    // when calling `addDependency`
+    delete localLibPkgJson.version;
+    await fs.writeJSON(localLibPkgPath, localLibPkgJson);
+
+    let app = Project.fromDir(template.baseDir, { linkDeps: true });
+    await expect(app.write()).rejects.toThrowError(
+      'No version found for package local-lib. All dependencies must have both a name and version in their package.json.'
+    );
+
+    template.dispose();
+    app.dispose();
+  });
+
+  it('can read a project with linked dev dependencies', async () => {
+    // start with a template app
+    let appTemplate = new Project('stock-app');
+    appTemplate.addDependency('helper-lib', '1.2.3');
+    appTemplate.addDevDependency('test-lib');
+    appTemplate.files['hello.js'] = '// it works';
+    await appTemplate.write();
+
+    // build a new addon from the template
+    let myApp = Project.fromDir(appTemplate.baseDir, { linkDevDeps: true });
+    myApp.name = 'custom-addon';
+    myApp.files['layered-extra.js'] = '// extra stuff';
+    await myApp.write();
+
+    expect(fs.readlinkSync(path.join(myApp.baseDir, 'node_modules', 'helper-lib'))).to.eql(
+      path.join(appTemplate.baseDir, 'node_modules', 'helper-lib')
+    );
+
+    expect(fs.readlinkSync(path.join(myApp.baseDir, 'node_modules', 'test-lib'))).to.eql(
+      path.join(appTemplate.baseDir, 'node_modules', 'test-lib')
+    );
+
+    expect(fs.existsSync(path.join(myApp.baseDir, 'hello.js'))).to.eql(true);
+    expect(fs.existsSync(path.join(myApp.baseDir, 'layered-extra.js'))).to.eql(true);
+  });
+
+  it('can override a linked dependency with a new Project dependency', async () => {
+    let baseProject = new Project('base');
+    baseProject.addDependency('moment', '1.2.3');
+    await baseProject.write();
+
+    let project = Project.fromDir(baseProject.baseDir, { linkDeps: true });
+    project.addDependency('moment', '4.5.6');
+    await project.write();
+    expect(fs.lstatSync(path.join(project.baseDir, 'node_modules', 'moment')).isSymbolicLink()).to.eql(false);
+    expect(fs.readJSONSync(path.join(project.baseDir, 'node_modules', 'moment', 'package.json')).version).to.eql(
+      '4.5.6'
+    );
+  });
+
+  it('can override a Project dependency with a linked dependency', async () => {
+    let dep = new Project('dep', '1.2.3');
+    dep.files['first.js'] = '';
+    await dep.write();
+
+    let project = new Project('app');
+    let dep2 = project.addDependency('dep', '4.5.6');
+    dep2.files['second.js'] = '';
+    project.linkDependency('dep', { target: dep.baseDir });
+    await project.write();
+    expect(fs.lstatSync(path.join(project.baseDir, 'node_modules', 'dep')).isSymbolicLink(), 'is symlink').is.true;
+    expect(
+      fs.readJSONSync(path.join(project.baseDir, 'node_modules', 'dep', 'package.json')).version,
+      'version'
+    ).to.eql('1.2.3');
+    expect(fs.existsSync(path.join(project.baseDir, 'node_modules', 'dep', 'first.js')), 'first.js').is.true;
+    expect(fs.existsSync(path.join(project.baseDir, 'node_modules', 'dep', 'second.js')), 'second.js').is.false;
+  });
+
+  it('can remove a linked dependency', async () => {
+    let dep = new Project('dep', '1.2.3');
+    dep.files['first.js'] = '';
+    await dep.write();
+
+    let project = new Project('app');
+    project.linkDependency('dep', { target: dep.baseDir });
+    project.removeDependency('dep');
+    await project.write();
+    expect(fs.readJSONSync(path.join(project.baseDir, 'package.json')).dependencies?.dep).to.be.undefined;
+    expect(fs.existsSync(path.join(project.baseDir, 'node_modules', 'dep'))).is.false;
+  });
+
+  it('preserves linking behaviors through clone', async () => {
+    let baseProject = new Project('base');
+    await baseProject.write();
+
+    let project = new Project('my-app');
+    project.linkDependency('moment', { target: baseProject.baseDir });
+    let cloned = project.clone();
+    await cloned.write();
+    expect(fs.readlinkSync(path.join(cloned.baseDir, 'node_modules', 'moment'))).to.eql(baseProject.baseDir);
+  });
+
+  it('can choose the requested semver range of a dependency', async () => {
+    let proj = new Project();
+    proj.addDependency('mylib', { version: '1.2.3', requestedRange: '^1' });
+    await proj.write();
+    expect(fs.readJSONSync(path.join(proj.baseDir, 'package.json')).dependencies.mylib).to.eql('^1');
+  });
+
+  it('can choose the requested semver range of a linked dependency', async () => {
+    let baseProject = new Project('moment', '1.2.3');
+    await baseProject.write();
+
+    let project = new Project('my-app');
+    project.linkDependency('moment', { target: baseProject.baseDir, requestedRange: '^1' });
+    await project.write();
+    expect(fs.readJSONSync(path.join(project.baseDir, 'package.json')).dependencies.moment).to.eql('^1');
+  });
+
+  it('links bin entry in package', async () => {
+    let project = new Project('my-app', '1.0.0');
+    project.pkg['license'] = 'MIT';
+
+    project.addDependency({
+      files: {
+        'package.json': JSON.stringify({
+          name: 'my-cli',
+          version: '1.0.0',
+          bin: { hello: 'hello.js', goodbye: 'goodbye.js' },
+        }),
+        'hello.js': `#!/usr/bin/env node
+        require("./index.js")("hello")`,
+        'goodbye.js': `#!/usr/bin/env node
+        require("./index.js")("goodbye")`,
+        'index.js': `module.exports = (s) => console.log(s)`,
+      },
+    });
+
+    await project.write();
+
+    const { execFileSync } = require('child_process');
+
+    expect(
+      execFileSync('yarn', ['-s', 'run', 'hello'], {
+        cwd: project.baseDir,
+        encoding: 'utf8',
+      })
+    ).to.eql('hello\n');
+
+    const binPath = execFileSync('yarn', ['bin'], {
+      cwd: project.baseDir,
+      encoding: 'utf8',
+    }).trimEnd();
+
+    expect(execFileSync(path.join(binPath, 'goodbye'), { encoding: 'utf8' })).to.eql('goodbye\n');
+  });
+
+  it('should not share files', function () {
+    let project1 = new Project('my-app', '1.0.0');
+    project1.files['foo.js'] = 'foo';
+
+    let project2 = new Project('my-app', '1.0.0');
+
+    expect(project2.files['foo.js']).to.be.undefined;
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,20 +4,14 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "strict": true,
-    "module": "esnext",
-    "moduleResolution": "node",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "esModuleInterop": true,
-    "target": "es2018",
-    "baseUrl": ".",
+    "target": "es2022",
     "outDir": "dist",
     "rootDir": "src",
     "skipLibCheck": true,
-    "paths": {
-      "*": ["./types/*"]
-    }
+    "types": ["./types/bin-links.d.ts"]
   },
   "include": ["./src"],
   "exclude": ["**/node_modules/**"]


### PR DESCRIPTION
Since we're only supporting node >=22 now we should be able to only deploy the esm version of this lib 🎉 https://github.com/stefanpenner/node-fixturify-project/pull/105

This PR simplifies the build (removing tsup) and stops trying to test the cjs version of the lib (because it's not being built any more)