### PR TITLE
update release-plan workflows to support OIDC

### DIFF
--- a/.github/workflows/plan-release.yml
+++ b/.github/workflows/plan-release.yml
@@ -1,5 +1,6 @@
-name: Release Plan Review
+name: Plan Release
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -14,71 +15,44 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check-plan:
-    name: "Check Release Plan"
+  should-run-release-plan-prepare:
+    name: Should we run release-plan prepare?
     runs-on: ubuntu-latest
     outputs:
-      command: ${{ steps.check-release.outputs.command }}
-
+      should-prepare: ${{ steps.should-prepare.outputs.should-prepare }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: release-plan/actions/should-prepare-release@v1
         with:
-          fetch-depth: 0
           ref: 'master'
-      # This will only cause the `check-plan` job to have a "command" of `release`
-      # when the .release-plan.json file was changed on the last commit.
-      - id: check-release
-        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
+        id: should-prepare
 
-  prepare_release_notes:
-    name: Prepare Release Notes
+  create-prepare-release-pr:
+    name: Create Prepare Release PR
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: check-plan
+    needs: should-run-release-plan-prepare
     permissions:
       contents: write
       issues: read
       pull-requests: write
-    outputs:
-      explanation: ${{ steps.explanation.outputs.text }}
-    # only run on push event if plan wasn't updated (don't create a release plan when we're releasing)
-    # only run on labeled event if the PR has already been merged
-    if: (github.event_name == 'push' && needs.check-plan.outputs.command != 'release') || (github.event_name == 'pull_request_target' && github.event.pull_request.merged == true)
-
+    if: needs.should-run-release-plan-prepare.outputs.should-prepare == 'true'
     steps:
-      - uses: actions/checkout@v4
-        # We need to download lots of history so that
-        # github-changelog can discover what's changed since the last release
+      - uses: release-plan/actions/prepare@v1
+        name: Run release-plan prepare
         with:
-          fetch-depth: 0
           ref: 'master'
-      - uses: jdx/mise-action@v4
-      - run: pnpm install --frozen-lockfile
-      - name: "Generate Explanation and Prep Changelogs"
-        id: explanation
-        run: |
-          set +e
-          pnpm release-plan prepare 2> >(tee -a release-plan-stderr.txt >&2)
-
-          if [ $? -ne 0 ]; then
-            echo 'text<<EOF' >> $GITHUB_OUTPUT
-            cat release-plan-stderr.txt >> $GITHUB_OUTPUT
-            echo 'EOF' >> $GITHUB_OUTPUT
-          else
-            echo 'text<<EOF' >> $GITHUB_OUTPUT
-            jq .description .release-plan.json -r >> $GITHUB_OUTPUT
-            echo 'EOF' >> $GITHUB_OUTPUT
-            rm release-plan-stderr.txt
-          fi
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
+        id: explanation
 
-      - uses: peter-evans/create-pull-request@v6
+      - uses: peter-evans/create-pull-request@v8
+        name: Create Prepare Release PR
         with:
-          commit-message: "Prepare Release using 'release-plan'"
+          commit-message: "Prepare Release ${{ steps.explanation.outputs.new-version}} using 'release-plan'"
           labels: "internal"
+          sign-commits: true
           branch: release-preview
-          title: Prepare Release
+          title: Prepare Release ${{ steps.explanation.outputs.new-version }}
           body: |
             This PR is a preview of the release that [release-plan](https://github.com/embroider-build/release-plan) has prepared. To release you should just merge this PR 👍
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,6 +1,5 @@
-# For every push to the master branch, this checks if the release-plan was
-# updated and if it was it will publish stable npm packages based on the
-# release plan
+# For every push to the primary branch with .release-plan.json modified,
+# runs release-plan.
 
 name: Publish Stable
 
@@ -10,51 +9,32 @@ on:
     branches:
       - main
       - master
+    paths:
+      - '.release-plan.json'
 
 concurrency:
   group: publish-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  check-plan:
-    name: "Check Release Plan"
-    runs-on: ubuntu-latest
-    outputs:
-      command: ${{ steps.check-release.outputs.command }}
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          ref: 'master'
-      # This will only cause the `check-plan` job to have a result of `success`
-      # when the .release-plan.json file was changed on the last commit. This
-      # plus the fact that this action only runs on main will be enough of a guard
-      - id: check-release
-        run: if git diff --name-only HEAD HEAD~1 | grep -w -q ".release-plan.json"; then echo "command=release"; fi >> $GITHUB_OUTPUT
-
   publish:
     name: "NPM Publish"
     runs-on: ubuntu-latest
-    needs: check-plan
-    if: needs.check-plan.outputs.command == 'release'
     permissions:
       contents: write
-      pull-requests: write
+      id-token: write
+      attestations: write
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: jdx/mise-action@v4
-      - name: Configure npm registry auth
-        # mise-action does not configure npm auth the way actions/setup-node's
-        # `registry-url` did. Write the auth line explicitly; the literal
-        # ${NODE_AUTH_TOKEN} placeholder is expanded by pnpm at publish time.
-        run: |
-          echo '//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}' >> .npmrc
-          echo 'registry=https://registry.npmjs.org/' >> .npmrc
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: 'https://registry.npmjs.org'
+          cache: pnpm
       - run: pnpm install --frozen-lockfile
-      - name: npm publish
-        run: pnpm release-plan publish
+      - name: Publish to NPM
+        run: NPM_CONFIG_PROVENANCE=true pnpm release-plan publish
         env:
           GITHUB_AUTH: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -4,21 +4,21 @@ Releases in this repo are mostly automated using [release-plan](https://github.c
 
 ## Preparation
 
-Since the majority of the actual release process is automated, the remaining tasks before releasing are: 
+Since the majority of the actual release process is automated, the remaining tasks before releasing are:
 
--  correctly labeling **all** pull requests that have been merged since the last release
--  updating pull request titles so they make sense to our users
+- correctly labeling **all** pull requests that have been merged since the last release
+- updating pull request titles so they make sense to our users
 
 Some great information on why this is important can be found at [keepachangelog.com](https://keepachangelog.com/en/1.1.0/), but the overall
 guiding principle here is that changelogs are for humans, not machines.
 
 When reviewing merged PR's the labels to be used are:
 
-* breaking - Used when the PR is considered a breaking change.
-* enhancement - Used when the PR adds a new feature or enhancement.
-* bug - Used when the PR fixes a bug included in a previous release.
-* documentation - Used when the PR adds or updates documentation.
-* internal - Internal changes or things that don't fit in any other category.
+- breaking - Used when the PR is considered a breaking change.
+- enhancement - Used when the PR adds a new feature or enhancement.
+- bug - Used when the PR fixes a bug included in a previous release.
+- documentation - Used when the PR adds or updates documentation.
+- internal - Internal changes or things that don't fit in any other category.
 
 **Note:** `release-plan` requires that **all** PRs are labeled. If a PR doesn't fit in a category it's fine to label it as `internal`
 


### PR DESCRIPTION
Hey @rwjblue @scalvert 👋 long time no see 😂 

I don't know if you've been following release-plan but I noticed that you have a `Prepare release` pr going with a breaking change https://github.com/stefanpenner/node-fixturify-project/pull/107

Because of the world being what it is 🫠 you can't merge that PR yet to release. You need to merge this one and then setup OIDC on npm. Once you have done both those things all you need to do is merge the `Prepare release` PR and it will automatically release for you 👍 